### PR TITLE
⚡ Loosen Requirements for Classical Stimuli Generation

### DIFF
--- a/include/checker/dd/simulation/StateGenerator.hpp
+++ b/include/checker/dd/simulation/StateGenerator.hpp
@@ -47,9 +47,7 @@ namespace ec {
             // check if there still is a unique computational basis state
             if (randomQubits <= 63) {
                 const std::uint_least64_t maxStates = (static_cast<std::uint_least64_t>(1U) << randomQubits);
-                if (generatedComputationalBasisStates.size() == maxStates) {
-                    throw std::runtime_error("No more unique basis states available.");
-                }
+                assert(generatedComputationalBasisStates.size() != maxStates);
                 // generate a unique computational basis state
                 std::uniform_int_distribution<std::uint_least64_t> distribution(0, maxStates - 1);
                 auto [randomState, success] = generatedComputationalBasisStates.insert(distribution(mt));

--- a/include/checker/dd/simulation/StateGenerator.hpp
+++ b/include/checker/dd/simulation/StateGenerator.hpp
@@ -41,29 +41,41 @@ namespace ec {
         template<class DDPackage = dd::Package<>>
         qc::VectorDD generateRandomComputationalBasisState(std::unique_ptr<DDPackage>& dd, dd::QubitCount totalQubits, dd::QubitCount ancillaryQubits = 0U) {
             // determine how many qubits truly are random
-            const auto randomQubits = totalQubits - ancillaryQubits;
-            if (randomQubits > static_cast<dd::QubitCount>(std::mt19937_64::word_size) - 1) {
-                throw std::runtime_error("Generation of computational basis states currently only supports up to 63 qubits.");
-            }
+            const auto        randomQubits = totalQubits - ancillaryQubits;
+            std::vector<bool> stimulusBits(totalQubits, false);
 
             // check if there still is a unique computational basis state
-            const std::uint_least64_t maxStates = (static_cast<std::uint_least64_t>(1U) << randomQubits);
-            if (generatedComputationalBasisStates.size() == maxStates) {
-                throw std::runtime_error("No more unique basis states available.");
-            }
+            if (randomQubits <= 63) {
+                const std::uint_least64_t maxStates = (static_cast<std::uint_least64_t>(1U) << randomQubits);
+                if (generatedComputationalBasisStates.size() == maxStates) {
+                    throw std::runtime_error("No more unique basis states available.");
+                }
+                // generate a unique computational basis state
+                std::uniform_int_distribution<std::uint_least64_t> distribution(0, maxStates - 1);
+                auto [randomState, success] = generatedComputationalBasisStates.insert(distribution(mt));
+                while (!success) {
+                    std::tie(randomState, success) = generatedComputationalBasisStates.insert(distribution(mt));
+                }
 
-            // generate a unique computational basis state
-            std::uniform_int_distribution<std::uint_least64_t> distribution(0, maxStates - 1);
-            auto [randomState, success] = generatedComputationalBasisStates.insert(distribution(mt));
-            while (!success) {
-                std::tie(randomState, success) = generatedComputationalBasisStates.insert(distribution(mt));
-            }
-
-            // generate the bitvector corresponding to the random state
-            std::vector<bool> stimulusBits(totalQubits, false);
-            for (dd::QubitCount i = 0; i < randomQubits; ++i) {
-                if (*randomState & (static_cast<std::uint_least64_t>(1U) << i)) {
-                    stimulusBits[i] = true;
+                // generate the bitvector corresponding to the random state
+                for (dd::QubitCount i = 0; i < randomQubits; ++i) {
+                    if (*randomState & (static_cast<std::uint_least64_t>(1U) << i)) {
+                        stimulusBits[i] = true;
+                    }
+                }
+            } else {
+                // check how many 64bit numbers are needed for each random state
+                const auto nr = static_cast<std::size_t>(std::ceil(randomQubits / 64.));
+                // generate enough random numbers
+                std::vector<std::mt19937_64::result_type> randomNumbers(nr, 0U);
+                for (auto i = 0U; i < nr; ++i) {
+                    randomNumbers[i] = mt();
+                }
+                // generate the corresponding bitvector
+                for (dd::QubitCount i = 0U; i < randomQubits; ++i) {
+                    if (randomNumbers[i / 64U] & (static_cast<std::uint_least64_t>(1U) << (i % 64U))) {
+                        stimulusBits[i] = true;
+                    }
                 }
             }
 

--- a/src/EquivalenceCheckingManager.cpp
+++ b/src/EquivalenceCheckingManager.cpp
@@ -231,7 +231,7 @@ namespace ec {
         if (configuration.execution.runSimulationChecker && configuration.simulation.stateType == StateType::ComputationalBasis) {
             const auto        nq           = this->qc1.getNqubitsWithoutAncillae();
             const std::size_t uniqueStates = 1ULL << nq;
-            if (configuration.simulation.maxSims > uniqueStates) {
+            if (nq <= 63U && configuration.simulation.maxSims > uniqueStates) {
                 this->configuration.simulation.maxSims = uniqueStates;
             }
         }

--- a/test/test_equality.cpp
+++ b/test/test_equality.cpp
@@ -111,3 +111,17 @@ TEST_F(EqualityTest, CloseButNotEqualSimulation) {
     std::cout << ecm << std::endl;
     EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::ProbablyEquivalent);
 }
+
+TEST_F(EqualityTest, SimulationMoreThan64Qubits) {
+    qc1 = qc::QuantumComputation(65U);
+    qc1.h(0);
+    for (auto i = 0U; i < 64U; ++i) {
+        qc1.x(static_cast<dd::Qubit>(i + 1), 0_pc);
+    }
+    qc2                                   = qc1.clone();
+    config.execution.runSimulationChecker = true;
+    ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
+    ecm.run();
+    std::cout << ecm << std::endl;
+    EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::ProbablyEquivalent);
+}


### PR DESCRIPTION
This PR eliminates a bug that prevented circuits with more than 63 qubits to be checked for equivalence with the default settings. To this end, classical stimuli with an arbitrary number of qubits can now be generated.