### PR TITLE
🐛 Small bugfix update

### DIFF
--- a/docs/source/install/Developers.rst
+++ b/docs/source/install/Developers.rst
@@ -47,9 +47,11 @@ The :code:`mqt.qcec` Python module can be conveniently built locally by calling
 
     .. code-block:: console
 
-        (venv) $ pip install --editable .
+        (venv) $ pip install --editable .[dev]
 
-The :code:`--editable` flag ensures that changes in the Python code are instantly available without re-running the command.
+The :code:`--editable` flag ensures that changes in the Python code are instantly available without re-running the command. The :code:`[dev]` extra makes sure that all dependencies for running the Python tests and building the documentation are available.
+
+**Disclaimer**: When using the :code:`zsh` shell it might be necessary to add double quotes around the :code:`.[dev]` part of the command.
 
 `Pybind11 <https://pybind11.readthedocs.io/>`_ is used for providing bindings of the C++ core library to Python (see `bindings.cpp <https://github.com/cda-tum/qcec/tree/master/mqt/qcec/bindings.cpp>`_).
 If parts of the C++ code have been changed, the above command has to be run again to make the changes visible in Python.

--- a/jkq/__init__.py
+++ b/jkq/__init__.py
@@ -1,5 +1,5 @@
 import warnings
-from mqt import *
+from mqt import qcec
 
 warnings.simplefilter('always', DeprecationWarning)
 warnings.warn('Usage via `import jkq` is deprecated in favor of the new prefix. Please use `import mqt` instead.', DeprecationWarning)

--- a/mqt/qcec/bindings.cpp
+++ b/mqt/qcec/bindings.cpp
@@ -137,7 +137,7 @@ namespace ec {
         return createManagerFromConfiguration(circ1, circ2, configuration);
     }
 
-    ec::EquivalenceCheckingManager::Results verify(const py::object& circ1, const py::object& circ2, const Configuration& configuration) {
+    ec::EquivalenceCheckingManager::Results verify(const py::object& circ1, const py::object& circ2, const Configuration& configuration = Configuration()) {
         auto ecm = createManagerFromConfiguration(circ1, circ2, configuration);
         ecm->run();
         return ecm->getResults();

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ build-backend = "setuptools.build_meta"
 build = "cp3*"
 archs = "auto64"
 test-skip = "*-macosx_arm64 *-musllinux* *aarch64"
-test-extras = ["tests"]
+test-extras = ["test"]
 test-command = "python -m pytest {project}/test/python"
 environment = { DEPLOY = "ON" }
 build-frontend = "build"

--- a/setup.py
+++ b/setup.py
@@ -106,8 +106,9 @@ setup(
     include_package_data=True,
     package_data={'': ['profiles/*.profile']},
     extras_require={
-        "tests": ["pytest~=7.1.1", "qiskit-terra>=0.19.2,<0.21.0"],
-        "docs": ["sphinx==5.0.2", "sphinx-rtd-theme==1.0.0", "sphinxcontrib-bibtex==2.4.2", "sphinx-copybutton==0.4.0"]
+        "test": ["pytest~=7.1.1", "qiskit-terra>=0.19.2,<0.21.0"],
+        "docs": ["sphinx==5.0.2", "sphinx-rtd-theme==1.0.0", "sphinxcontrib-bibtex==2.4.2", "sphinx-copybutton==0.4.0"],
+        "dev": ["mqt.qcec[test, docs]"]  # requires Pip 21.2 or newer
     },
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
This PR adopts a couple of very small bugfixes:
 - the `verify` function was missing a default argument for the `configuration` parameter in the bindings
 - a bug in the QFR library Qiskit `Layout` import prevented the import of circuits with a non-empty `_layout`but without an ancillary register
 - the `tests` extra has been renamed to `test` which seems to be the more commonly used name
 - a new `dev` extra has been added that installs all dependencies for development in one go.