### PR TITLE
📝 Documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@
 
 # MQT QCEC - A tool for Quantum Circuit Equivalence Checking
 
-A tool for quantum circuit equivalence checking developed by the [Chair for Design Automation](https://www.cda.cit.tum.de/) at the [Technical University of Munich](https://www.tum.de/). 
-QCEC is part of the Munich Quantum Toolkit (MQT; formerly known as JKQ and developed by the [Institute for Integrated Circuits](https://iic.jku.at/eda/) at the [Johannes Kepler University Linz](https://jku.at)). 
+A tool for quantum circuit equivalence checking developed as part of the *Munich Quantum Toolkit* (*MQT*)[^1] by the [Chair for Design Automation](https://www.cda.cit.tum.de/) at the [Technical University of Munich](https://www.tum.de/).
 It builds upon [our quantum functionality representation (QFR)](https://github.com/cda-tum/qfr)
 and [our decision diagram (DD) package](https://github.com/cda-tum/dd_package.git).
 
@@ -59,3 +58,5 @@ L. Burgholzer, R. Kueng, and R. Wille, "[Random Stimuli Generation for the Verif
 
 [![a](https://img.shields.io/static/v1?label=arXiv&message=2106.01099&color=inactive&style=flat-square)](https://arxiv.org/abs/2106.01099)  
 L. Burgholzer and R. Wille, "[Handling Non-Unitaries in Quantum Circuit Equivalence Checking](https://arxiv.org/abs/2106.01099)," in Design Automation Conference (DAC), 2022
+
+[^1]: The Munich Quantum Toolkit was formerly known under the acronym *JKQ* and developed by the [Institute for Integrated Circuits](https://iic.jku.at/eda/) at the [Johannes Kepler University Linz](https://jku.at)). 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,13 +1,11 @@
 Welcome to QCEC's documentation!
 ================================
 
-QCEC is a tool for quantum circuit equivalence checking developed by the `Chair for Design Automation <https://www.cda.cit.tum.de/>`_ at the `Technical University of Munich <https://www.tum.de>`_.
-
-QCEC is part of the Munich Quantum Toolkit (MQT; formerly known as JKQ :cite:labelpar:`wille2020JKQtools` and developed by the `Institute for Integrated Circuits <https://iic.jku.at/eda/>`_ at the `Johannes Kepler University Linz <https://jku.at>`_).
-It builds upon `our quantum functionality representation (QFR) <https://github.com/cda-tum/qfr>`_ and `our decision diagram (DD) package <https://github.com/cda-tum/dd_package.git>`_.
+QCEC is a tool for :doc:`quantum circuit equivalence checking <EquivalenceChecking>` developed as part of the *Munich Quantum Toolkit* (*MQT*) [#]_ by the `Chair for Design Automation <https://www.cda.cit.tum.de/>`_ at the `Technical University of Munich <https://www.tum.de>`_. It builds upon `our quantum functionality representation (QFR) <https://github.com/cda-tum/qfr>`_ and `our decision diagram (DD) package <https://github.com/cda-tum/dd_package.git>`_.
 
 If you have any questions, feel free to contact us via `quantum.cda@xcit.tum.de <mailto:quantum.cda@xcit.tum.de>`_ or by creating an issue on `GitHub <https://github.com/cda-tum/qcec/issues>`_.
 
+----
 
 .. toctree::
    :maxdepth: 3
@@ -17,3 +15,9 @@ If you have any questions, feel free to contact us via `quantum.cda@xcit.tum.de 
    Installation
    Library
    Publications
+
+----
+
+.. rubric:: Footnotes
+
+.. [#] The Munich Quantum Toolkit was formerly known under the acronym *JKQ* :cite:labelpar:`wille2020JKQtools` and developed by the `Institute for Integrated Circuits <https://iic.jku.at/eda/>`_ at the `Johannes Kepler University Linz <https://jku.at>`_.

--- a/docs/source/install/Developers.rst
+++ b/docs/source/install/Developers.rst
@@ -11,6 +11,10 @@ Note the :code:`--recurse-submodules` flag. It is required to also clone all the
 
 A C++ compiler supporting *C++17* and a minimum CMake version of *3.14* is required to build the project.
 
+.. note::
+    We noticed some issues when compiling with Microsoft's *MSCV* compiler toolchain. If you want to start development on this project under Windows, consider using the *clang* compiler toolchain. A detailed description of how to set this up can be found `here <https://docs.microsoft.com/en-us/cpp/build/clang-support-msbuild?view=msvc-160>`_.
+
+
 Working on the core C++ library
 ###############################
 

--- a/docs/source/install/Developers.rst
+++ b/docs/source/install/Developers.rst
@@ -47,9 +47,73 @@ The :code:`mqt.qcec` Python module can be conveniently built locally by calling
 
     .. code-block:: console
 
-        (venv) $ pip install --editable .
+        (venv) $ pip install --editable .[dev]
 
-The :code:`--editable` flag ensures that changes in the Python code are instantly available without re-running the command.
+The :code:`--editable` flag ensures that changes in the Python code are instantly available without re-running the command. The :code:`[dev]` extra makes sure that all dependencies for running the Python tests and building the documentation are available.
 
-`Pybind11 <https://pybind11.readthedocs.io/>`_ is used for providing bindings of the C++ core library to Python (see `bindings.cpp <https://github.com/cda-tum/qcec/tree/master/mqt/qcec/bindings.cpp>`_).
+.. note::
+    When using the :code:`zsh` shell it might be necessary to add double quotes around the :code:`.[dev]` part of the command.
+
+`Pybind11 <https://pybind11.readthedocs.io/>`_ is used for providing bindings of the C++ core library to Python (see `bindings.cpp <https://github.com/cda-tum/qcec/tree/main/mqt/qcec/bindings.cpp>`_).
 If parts of the C++ code have been changed, the above command has to be run again to make the changes visible in Python.
+
+Running tests
+#############
+
+C++ core library
+----------------
+
+The C++ part of the code base is tested by unit tests using the `googletest <https://google.github.io/googletest/primer.html>`_ framework.
+The corresponding test files can be found in the :code:`test` directory. In order to build the tests, CMake first has to be configured with the :code:`-DBUILD_QCEC_TESTS=ON` flag, i.e.,
+
+    .. code-block:: console
+
+        $ cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_QCEC_TESTS=ON
+
+Then, the test executable :code:`qcec_test` is built in the :code:`build/test` directory by calling
+
+    .. code-block:: console
+
+        $ cmake --build build --config Release --target qcec_test
+
+From there, the tests can be started by simply calling
+
+    .. code-block:: console
+
+        [.../build/test] $ ./qcec_test
+
+Python interface and functionality
+----------------------------------
+
+The Python part of the code base is tested by unit tests using the `pytest <https://docs.pytest.org/en/latest/>`_ framework.
+The corresponding test files can be found in the :code:`test/python` directory.
+To start the tests, simply call
+
+    .. code-block:: console
+
+        (venv) $ python -m pytest ./test/python
+
+.. note::
+    If you haven't already installed the package with the :code:`[dev]` extra as demonstrated above, the necessary dependencies for running the Python tests can be installed by calling
+
+        .. code-block:: console
+
+            (venv) $ pip install --editable .[test]
+
+Building the documentation
+##########################
+
+Building this documentation locally is as easy as calling
+
+    .. code-block:: console
+
+        (venv) [.../docs] $ make clean && make html
+
+The resulting HTML documentation (:code:`index.html`) can be found in the :code:`docs/build/html` directory.
+
+.. note::
+    If you haven't already installed the package with the :code:`[dev]` extra as demonstrated above, the necessary dependencies for building the documentation can be installed by calling
+
+        .. code-block:: console
+
+            (venv) $ pip install --editable .[docs]

--- a/docs/source/install/Users.rst
+++ b/docs/source/install/Users.rst
@@ -89,4 +89,5 @@ This requires a `C++ compiler <https://en.wikipedia.org/wiki/List_of_compilers#C
 The library is continuously tested under Linux, MacOS, and Windows using the `latest available system versions for GitHub Actions <https://github.com/actions/virtual-environments>`_.
 In order to access the latest build logs, visit `qcec/actions/workflows/ci.yml <https://github.com/cda-tum/qcec/actions/workflows/ci.yml>`_.
 
-**Disclaimer**: We noticed some issues when compiling with Microsoft's *MSCV* compiler toolchain. If you want to start development on this project under Windows, consider using the *clang* compiler toolchain. A detailed description of how to set this up can be found `here <https://docs.microsoft.com/en-us/cpp/build/clang-support-msbuild?view=msvc-160>`_.
+.. note::
+    We noticed some issues when compiling with Microsoft's *MSCV* compiler toolchain. If you want to start development on this project under Windows, consider using the *clang* compiler toolchain. A detailed description of how to set this up can be found `here <https://docs.microsoft.com/en-us/cpp/build/clang-support-msbuild?view=msvc-160>`_.

--- a/docs/source/library/EquivalenceCheckingManager.rst
+++ b/docs/source/library/EquivalenceCheckingManager.rst
@@ -43,9 +43,10 @@ There are two ways of configuring the manager at construction time, e.g., in ord
 
         ecm = EquivalenceCheckingManager(circ1=qc1, circ2=qc2, timeout=60.)
 
-  Every keyword argument that takes an enum value can either be conveniently specified as a string (e.g., :code:`state_type="stabilizer"`) or by providing the respective enum value (e.g., :code:`state_type=qcec.StateType.stabilizer`).
+.. note::
+    Every keyword argument that takes an enum value can either be conveniently specified as a string (e.g., :code:`state_type="stabilizer"`) or by providing the respective enum value (e.g., :code:`state_type=qcec.StateType.stabilizer`).
 
-    .. automethod:: EquivalenceCheckingManager.__init__
+.. automethod:: EquivalenceCheckingManager.__init__
 
 Configuration after instantiation
 #################################


### PR DESCRIPTION
This PR updates parts of the documentation. Most importantly it adds information on how to build and run the C++ and Python tests and how to build the documentation locally.
Rather minor changes include the use of the dedicated `.. note::` role instead of manual disclaimers and the usage of footnotes to account for the JKQ/JKU/IIC legacy.