### PR TITLE
🚸🔧 Easy CLion configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 /build*
 /cmake-build-*
-.idea/
+/.idea/*
+!/.idea/runConfigurations
+!/.idea/cmake.xml
+.cache/
 
 __pycache__/
 *.so
@@ -20,3 +23,11 @@ var/
 .installed.cfg
 *.egg
 .pytest_cache/
+
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/

--- a/.idea/cmake.xml
+++ b/.idea/cmake.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CMakeSharedSettings">
+    <configurations>
+      <configuration PROFILE_NAME="Debug" ENABLED="true" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBUILD_QCEC_TESTS=ON -DBINDINGS=ON" />
+      <configuration PROFILE_NAME="Release" ENABLED="true" CONFIG_NAME="Release" GENERATION_OPTIONS="-DBUILD_QCEC_TESTS=ON -DBINDINGS=ON" />
+    </configurations>
+  </component>
+</project>

--- a/.idea/runConfigurations/pip.xml
+++ b/.idea/runConfigurations/pip.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="pip" type="PythonConfigurationType" factoryName="Python" singleton="false" nameIsGenerated="true">
+    <module name="qcec" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="$PROJECT_DIR$/venv/bin/python" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="IS_MODULE_SDK" value="true" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="SCRIPT_NAME" value="pip" />
+    <option name="PARAMETERS" value="install --editable &quot;.[dev]&quot; -vvv" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="true" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
This PR adds `cmake` build configuration and `pip` run configuration profiles for the [CLion IDE](https://www.jetbrains.com/clion/) to the project.

The cmake build profiles (`Debug` and `Release`) automatically specify the `-DBUILD_QCEC_TESTS=ON` flag for building tests and the `-DBINDINGS=ON` flag for building Python bindings. This saves the hassle of finding out why the `qcec_test` or the `pyqcec` target is not available.

The `pip` run configuration can be used to automatically build the project in editable mode with development dependencies. This allows to easily build the project python package locally.