### PR TITLE
🔧🐍 Add `qiskit-terra` to project dependencies

### DIFF
--- a/mqt/qcec/verify_compilation_flow.py
+++ b/mqt/qcec/verify_compilation_flow.py
@@ -1,10 +1,13 @@
 import pkg_resources
 from pathlib import Path
+from qiskit import QuantumCircuit
+from typing import Optional
+
 from mqt.qcec import EquivalenceCheckingManager, Configuration
 from mqt.qcec.compilation_flow_profiles import AncillaMode, generate_profile_name
 
 
-def verify_compilation(original_circuit, compiled_circuit,
+def verify_compilation(original_circuit: Optional[QuantumCircuit, str], compiled_circuit: Optional[QuantumCircuit, str],
                        optimization_level: int = 1, ancilla_mode: AncillaMode = AncillaMode.NO_ANCILLA,
                        configuration: Configuration = Configuration()) -> EquivalenceCheckingManager.Results:
     # create the equivalence checker

--- a/mqt/qcec/verify_compilation_flow.py
+++ b/mqt/qcec/verify_compilation_flow.py
@@ -1,13 +1,13 @@
 import pkg_resources
 from pathlib import Path
 from qiskit import QuantumCircuit
-from typing import Optional
+from typing import Union
 
 from mqt.qcec import EquivalenceCheckingManager, Configuration
 from mqt.qcec.compilation_flow_profiles import AncillaMode, generate_profile_name
 
 
-def verify_compilation(original_circuit: Optional[QuantumCircuit, str], compiled_circuit: Optional[QuantumCircuit, str],
+def verify_compilation(original_circuit: Union[QuantumCircuit, str], compiled_circuit: Union[QuantumCircuit, str],
                        optimization_level: int = 1, ancilla_mode: AncillaMode = AncillaMode.NO_ANCILLA,
                        configuration: Configuration = Configuration()) -> EquivalenceCheckingManager.Results:
     # create the equivalence checker

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,7 @@ setup(
     packages=find_namespace_packages(include=['mqt.*']),
     include_package_data=True,
     package_data={'': ['profiles/*.profile']},
+    install_requires=["qiskit-terra~=0.20.2"],
     extras_require={
         "test": ["pytest~=7.1.1", "qiskit-terra>=0.19.2,<0.21.0"],
         "docs": ["sphinx==5.0.2", "sphinx-rtd-theme==1.0.0", "sphinxcontrib-bibtex==2.4.2", "sphinx-copybutton==0.4.0"],

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setup(
     package_data={'': ['profiles/*.profile']},
     install_requires=["qiskit-terra~=0.20.2"],
     extras_require={
-        "test": ["pytest~=7.1.1", "qiskit-terra>=0.19.2,<0.21.0"],
+        "test": ["pytest~=7.1.1"],
         "docs": ["sphinx==5.0.2", "sphinx-rtd-theme==1.0.0", "sphinxcontrib-bibtex==2.4.2", "sphinx-copybutton==0.4.0"],
         "dev": ["mqt.qcec[test, docs]"]  # requires Pip 21.2 or newer
     },


### PR DESCRIPTION
This PR adds `qiskit-terra` to the project dependencies of QCEC, which more clearly conveys our preferred way of using QCEC.
Furthermore, this should fix the documentation errors that were unfortunately not caught by the CI.
