### PR TITLE
✨ Early Termination of ZX Checker

### DIFF
--- a/include/checker/zx/ZXChecker.hpp
+++ b/include/checker/zx/ZXChecker.hpp
@@ -4,6 +4,7 @@
 #include "Definitions.hpp"
 #include "EquivalenceCriterion.hpp"
 #include "QuantumComputation.hpp"
+#include "Simplify.hpp"
 #include "ZXDiagram.hpp"
 #include "checker/EquivalenceChecker.hpp"
 #include "nlohmann/json.hpp"
@@ -24,6 +25,77 @@ namespace ec {
         zx::ZXDiagram miter;
         zx::fp        tolerance;
         bool          ancilla = false;
+
+        // the following methods are adaptations of the core ZX simplification routines
+        // that additionally check a criterion for early termination of the simplification.
+        std::size_t fullReduceApproximate();
+        std::size_t fullReduce();
+
+        std::size_t gadgetSimp();
+        std::size_t interiorCliffordSimp();
+        std::size_t cliffordSimp();
+
+        std::size_t idSimp() {
+            return simplifyVertices(zx::checkIdSimp, zx::removeId);
+        }
+
+        std::size_t spiderSimp() {
+            return simplifyEdges(zx::checkSpiderFusion, zx::fuseSpiders);
+        }
+
+        std::size_t localCompSimp() {
+            return simplifyVertices(zx::checkLocalComp, zx::localComp);
+        }
+
+        std::size_t pivotPauliSimp() {
+            return simplifyEdges(zx::checkPivotPauli, zx::pivotPauli);
+        }
+
+        std::size_t pivotSimp() {
+            return simplifyEdges(zx::checkPivot, zx::pivot);
+        }
+
+        std::size_t pivotGadgetSimp() {
+            return simplifyEdges(zx::checkPivotGadget, zx::pivotGadget);
+        }
+
+        template<class CheckFun = zx::VertexCheckFun, class RuleFun = zx::VertexRuleFun>
+        std::size_t simplifyVertices(CheckFun check, RuleFun rule) {
+            std::size_t nSimplifications = 0;
+            bool        newMatches       = true;
+
+            while (!isDone() && newMatches) {
+                newMatches = false;
+                for (const auto& [v, _]: miter.getVertices()) {
+                    if (isDone() || !check(miter, v)) {
+                        continue;
+                    }
+                    rule(miter, v);
+                    newMatches = true;
+                    nSimplifications++;
+                }
+            }
+            return nSimplifications;
+        }
+
+        template<class CheckFun = zx::EdgeCheckFun, class RuleFun = zx::EdgeRuleFun>
+        std::size_t simplifyEdges(CheckFun check, RuleFun rule) {
+            std::size_t nSimplifications = 0;
+            bool        newMatches       = true;
+
+            while (!isDone() && newMatches) {
+                newMatches = false;
+                for (const auto& [v0, v1]: miter.getEdges()) {
+                    if (isDone() || miter.isDeleted(v0) || miter.isDeleted(v1) || !check(miter, v0, v1)) {
+                        continue;
+                    }
+                    rule(miter, v0, v1);
+                    newMatches = true;
+                    nSimplifications++;
+                }
+            }
+            return nSimplifications;
+        }
     };
 
     qc::Permutation complete(const qc::Permutation& p, dd::Qubit n);


### PR DESCRIPTION
This PR adds the means to allow for early termination in the ZX-based equivalence checker and eliminates waiting on a result when it is no longer needed.

To this end, the modular structure of the ZX Package is exploited and parts of the *simplification* code of the ZX Package is replicated in QCEC with additional termination checks.

This eventually allows to conveniently use the ZX checker per default without always waiting for it to finish.