### PR TITLE
🚸 Improve Python Compatibility of Documentation Building

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,7 @@
-from importlib.metadata import version
+try:
+    from importlib import metadata
+except ImportError:
+    import importlib_metadata as metadata
 import pybtex.plugin
 from pybtex.style.formatting.unsrt import Style as UnsrtStyle
 from pybtex.style.template import field, href
@@ -7,7 +10,7 @@ from pybtex.style.template import field, href
 project = 'QCEC'
 author = 'Lukas Burgholzer'
 
-release = version('mqt.qcec')
+release = metadata.version('mqt.qcec')
 version = '.'.join(release.split('.')[:3])
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,15 @@ setup(
     install_requires=["qiskit-terra>=0.20.2,<0.22.0"],
     extras_require={
         "test": ["pytest~=7.1.1"],
-        "docs": ["sphinx==5.0.2", "sphinx-rtd-theme==1.0.0", "sphinxcontrib-bibtex==2.4.2", "sphinx-copybutton==0.4.0", "sphinx-hoverxref==1.1.3"],
+        "docs": [
+            "sphinx==5.0.2",
+            "sphinx-rtd-theme==1.0.0",
+            "sphinxcontrib-bibtex==2.4.2",
+            "sphinx-copybutton==0.4.0",
+            "sphinx-hoverxref==1.1.3",
+            "pybtex>=0.24",
+            "importlib_metadata>=3.6; python_version < '3.10'"
+        ],
         "dev": ["mqt.qcec[test, docs]"]  # requires Pip 21.2 or newer
     },
     classifiers=[


### PR DESCRIPTION
The `importlib` module is only available for `Python >=3.8` and has gained a lot more functionality since `3.10`.
This PR improves the Python version compatibility for building QCEC's documentation by introducing a fallback option for determining the package version.

Furthermore, it explicitly adds `pybtex` to the documentation requirements (`docs`).