### PR TITLE
🔧🔥 Remove Workaround for Coverage Computation

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -13,3 +13,9 @@ coverage:
     patch:
       default:
         threshold: 1%
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: no
+      loop:        no

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,10 +92,8 @@ jobs:
       - name:              Test
         working-directory: ${{github.workspace}}/build/test
         run:               ./qcec_test
-      - name: Run gcov
-        run:  |
-              find . -type f -name '*.gcno' -exec gcov -p  {} +
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v3.1.0
         with:
-          fail_ci_if_error: true
+          gcov:        true
+          gcov_ignore: "extern/**/*"


### PR DESCRIPTION
Until recently, the new codecov uploader did not provide the option to run `gcov` on its own (or at least the option was not well documented), which required us to generate that data manually. 
This PR removes this workaround, since the option is now available again.

This required some further configuration changes since codecov now also considers branch coverage by default which we, at least at the moment, don't care about too much.