### PR TITLE
⚡🔧 Faster CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,78 +8,57 @@ on:
   workflow_dispatch:
 
 env:
-  BUILD_TYPE: Release
-  MAKEFLAGS:  "-j2"
+  MAKEFLAGS:  "-j3"
 
 defaults:
   run:
     shell: bash
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
-
+  ubuntu-ci:
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: recursive
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Configure CMake
+        run: cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DBUILD_QCEC_TESTS=ON -DBINDINGS=ON
+      - name: Build
+        run: cmake --build "${{github.workspace}}/build"
+      - name: Test
+        working-directory: ${{github.workspace}}/build/test
+        run: ctest --output-on-failure
 
-    - name: Configure CMake
-      run: |
-         if [ "$RUNNER_OS" == "Windows" ]; then
-           cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBINDINGS=ON -T "ClangCl"
-         else
-           cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBINDINGS=ON
-         fi  
-        
-    - name: Build
-      run: cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE
-
-  test:
-    needs: build
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-
+  macOS-ci:
+    runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: recursive
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Configure CMake
+        run: cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DBUILD_QCEC_TESTS=ON -DBINDINGS=ON
+      - name: Build
+        run: cmake --build "${{github.workspace}}/build"
+      - name: Test
+        working-directory: ${{github.workspace}}/build/test
+        run: ctest --output-on-failure
 
-    - name: Configure CMake
-      run: |
-         if [ "$RUNNER_OS" == "Windows" ]; then
-           cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_QCEC_TESTS=ON -T "ClangCl"
-         else
-           cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_QCEC_TESTS=ON -DBINDINGS=ON
-         fi  
-
-    - name: Build
-      run: |
-        if [ "$RUNNER_OS" == "Windows" ]; then
-          cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE
-        else
-          cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE --target qcec_test
-        fi  
-
-    - name: Test
-      working-directory: ${{github.workspace}}/build/test
-      run: |
-        if [ "$RUNNER_OS" == "Windows" ]; then
-          cd $BUILD_TYPE
-          ./qcec_test.exe
-        else
-          ./qcec_test
-        fi
+  windows-ci:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Configure CMake
+        run: cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=Release -DBUILD_QCEC_TESTS=ON -DBINDINGS=ON -T "ClangCl"
+      - name: Build
+        run: cmake --build "${{github.workspace}}/build" --config Release
+      - name: Test
+        working-directory: ${{github.workspace}}/build/test/Release
+        run: ./qcec_test.exe
     
   coverage:
-    needs: test
+    needs: ubuntu-ci
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,7 +8,7 @@ if (NOT TARGET gtest OR NOT TARGET gmock)
 			gtest_disable_pthreads gtest_force_shared_crt gtest_hide_internal_symbols
 	)
 	set_target_properties(gtest gtest_main gmock gmock_main PROPERTIES FOLDER extern)
-	if (BINDINGS)
+	if (BINDINGS AND NOT WIN32)
 		# adjust visibility settings for building Python bindings
 		target_compile_options(gtest PUBLIC -fvisibility=hidden)
 		target_compile_options(gmock PUBLIC -fvisibility=hidden)


### PR DESCRIPTION
Our continuous integration tests are taking more and more time with every feature we add.
As off now, we always did a separate `build` step before conducting the actual `test` step. 
Furthermore, the `coverage` test depended on the success of all previous jobs.
This wasted quite some time, because various OSs take various amounts of time (Linux typically being the quickest).

As a consequence, this PR unifies the `build` and `test` steps and splits the previous build matrix into three separate runners (one for each OS). The coverage check then only depends on the success of the Linux run (as it also runs on Linux).

Finally, the parallel build level is increased to `3`, which only has an effect on macOS as off now.