### PR TITLE
🎨🔧 Adopt (most of) LLVM's Code Format Style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,24 +1,7 @@
-BasedOnStyle:                              LLVM
-AccessModifierOffset:                      -4
-AlignConsecutiveAssignments:               Consecutive
-AlignConsecutiveDeclarations:              Consecutive
-AllowShortBlocksOnASingleLine:             Empty
-BraceWrapping:
-  SplitEmptyFunction:    false
-  SplitEmptyRecord:      false
-BreakConstructorInitializers:              AfterColon
-BreakInheritanceList:                      AfterColon
-ColumnLimit:                               0
-IncludeBlocks:                             Regroup
-IndentCaseLabels:                          true
-IndentPPDirectives:                        BeforeHash
-IndentWidth:                               4
-KeepEmptyLinesAtTheStartOfBlocks:          false
-NamespaceIndentation:                      All
-PointerAlignment:                          Left
-SpaceAfterTemplateKeyword:                 false
-SpaceBeforeCtorInitializerColon:           false
-SpaceBeforeInheritanceColon:               false
-SpaceBeforeRangeBasedForLoopColon:         false
-SpacesInAngles:                            false
-SpacesInContainerLiterals:                 false
+BasedOnStyle:                     LLVM
+AlignConsecutiveAssignments:      Consecutive
+AlignConsecutiveDeclarations:     Consecutive
+IncludeBlocks:                    Regroup
+KeepEmptyLinesAtTheStartOfBlocks: false
+PointerAlignment:                 Left
+SpacesInContainerLiterals:        false

--- a/include/Configuration.hpp
+++ b/include/Configuration.hpp
@@ -1,6 +1,6 @@
 //
-// This file is part of MQT QCEC library which is released under the MIT license.
-// See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
 #pragma once
@@ -18,161 +18,170 @@
 using namespace std::chrono_literals;
 
 namespace ec {
-    class Configuration {
-    public:
-        // configuration options for execution
-        struct Execution {
-            dd::fp numericalTolerance = dd::ComplexTable<>::tolerance();
+class Configuration {
+public:
+  // configuration options for execution
+  struct Execution {
+    dd::fp numericalTolerance = dd::ComplexTable<>::tolerance();
 
-            bool                 parallel = true;
-            std::size_t          nthreads = std::max(2U, std::thread::hardware_concurrency());
-            std::chrono::seconds timeout  = 0s;
+    bool        parallel = true;
+    std::size_t nthreads = std::max(2U, std::thread::hardware_concurrency());
+    std::chrono::seconds timeout = 0s;
 
-            bool runConstructionChecker = false;
-            bool runSimulationChecker   = true;
-            bool runAlternatingChecker  = true;
-            bool runZXChecker           = true;
-        };
+    bool runConstructionChecker = false;
+    bool runSimulationChecker   = true;
+    bool runAlternatingChecker  = true;
+    bool runZXChecker           = true;
+  };
 
-        // configuration options for pre-check optimizations
-        struct Optimizations {
-            bool fixOutputPermutationMismatch     = false;
-            bool fuseSingleQubitGates             = true;
-            bool reconstructSWAPs                 = true;
-            bool removeDiagonalGatesBeforeMeasure = false;
-            bool transformDynamicCircuit          = false;
-            bool reorderOperations                = true;
-        };
+  // configuration options for pre-check optimizations
+  struct Optimizations {
+    bool fixOutputPermutationMismatch     = false;
+    bool fuseSingleQubitGates             = true;
+    bool reconstructSWAPs                 = true;
+    bool removeDiagonalGatesBeforeMeasure = false;
+    bool transformDynamicCircuit          = false;
+    bool reorderOperations                = true;
+  };
 
-        // configuration options for application schemes
-        struct Application {
-            ApplicationSchemeType constructionScheme = ApplicationSchemeType::Proportional;
-            ApplicationSchemeType simulationScheme   = ApplicationSchemeType::Proportional;
-            ApplicationSchemeType alternatingScheme  = ApplicationSchemeType::Proportional;
+  // configuration options for application schemes
+  struct Application {
+    ApplicationSchemeType constructionScheme =
+        ApplicationSchemeType::Proportional;
+    ApplicationSchemeType simulationScheme =
+        ApplicationSchemeType::Proportional;
+    ApplicationSchemeType alternatingScheme =
+        ApplicationSchemeType::Proportional;
 
-            // options for the gate cost application scheme
-            std::string  profile{};
-            CostFunction costFunction = LegacyIBMCostFunction;
-        };
+    // options for the gate cost application scheme
+    std::string  profile{};
+    CostFunction costFunction = LegacyIBMCostFunction;
+  };
 
-        struct Functionality {
-            double traceThreshold = 1e-8;
-        };
+  struct Functionality {
+    double traceThreshold = 1e-8;
+  };
 
-        // configuration options for the simulation scheme
-        struct Simulation {
-            double      fidelityThreshold = 1e-8;
-            std::size_t maxSims           = std::max(16U, std::thread::hardware_concurrency() - 2U);
-            StateType   stateType         = StateType::ComputationalBasis;
-            std::size_t seed              = 0U;
-            bool        storeCEXinput     = false;
-            bool        storeCEXoutput    = false;
-        };
+  // configuration options for the simulation scheme
+  struct Simulation {
+    double      fidelityThreshold = 1e-8;
+    std::size_t maxSims =
+        std::max(16U, std::thread::hardware_concurrency() - 2U);
+    StateType   stateType      = StateType::ComputationalBasis;
+    std::size_t seed           = 0U;
+    bool        storeCEXinput  = false;
+    bool        storeCEXoutput = false;
+  };
 
-        Execution     execution{};
-        Optimizations optimizations{};
-        Application   application{};
-        Functionality functionality{};
-        Simulation    simulation{};
+  Execution     execution{};
+  Optimizations optimizations{};
+  Application   application{};
+  Functionality functionality{};
+  Simulation    simulation{};
 
-        [[nodiscard]] bool anythingToExecute() const noexcept {
-            return (execution.runSimulationChecker && simulation.maxSims > 0U) || execution.runAlternatingChecker || execution.runConstructionChecker || execution.runZXChecker;
-        }
+  [[nodiscard]] bool anythingToExecute() const noexcept {
+    return (execution.runSimulationChecker && simulation.maxSims > 0U) ||
+           execution.runAlternatingChecker ||
+           execution.runConstructionChecker || execution.runZXChecker;
+  }
 
-        [[nodiscard]] bool onlySingleTask() const noexcept {
-            // only a single simulation shall be performed
-            if (execution.runSimulationChecker && (simulation.maxSims == 1U) && !execution.runAlternatingChecker && !execution.runConstructionChecker) {
-                return true;
-            }
+  [[nodiscard]] bool onlySingleTask() const noexcept {
+    // only a single simulation shall be performed
+    if (execution.runSimulationChecker && (simulation.maxSims == 1U) &&
+        !execution.runAlternatingChecker && !execution.runConstructionChecker) {
+      return true;
+    }
 
-            // no simulations and only one of the other checks shall be performed
-            if (!execution.runSimulationChecker && (execution.runAlternatingChecker != execution.runConstructionChecker)) {
-                return true;
-            }
+    // no simulations and only one of the other checks shall be performed
+    if (!execution.runSimulationChecker &&
+        (execution.runAlternatingChecker != execution.runConstructionChecker)) {
+      return true;
+    }
 
-            return false;
-        }
+    return false;
+  }
 
-        [[nodiscard]] bool onlyZXCheckerConfigured() const noexcept {
-            return !execution.runConstructionChecker &&
-                   !execution.runSimulationChecker &&
-                   !execution.runAlternatingChecker &&
-                   execution.runZXChecker;
-        }
+  [[nodiscard]] bool onlyZXCheckerConfigured() const noexcept {
+    return !execution.runConstructionChecker &&
+           !execution.runSimulationChecker &&
+           !execution.runAlternatingChecker && execution.runZXChecker;
+  }
 
-        [[nodiscard]] bool onlySimulationCheckerConfigured() const noexcept {
-            return !execution.runConstructionChecker &&
-                   execution.runSimulationChecker &&
-                   !execution.runAlternatingChecker &&
-                   !execution.runZXChecker;
-        }
+  [[nodiscard]] bool onlySimulationCheckerConfigured() const noexcept {
+    return !execution.runConstructionChecker &&
+           execution.runSimulationChecker && !execution.runAlternatingChecker &&
+           !execution.runZXChecker;
+  }
 
-        [[nodiscard]] nlohmann::json json() const {
-            nlohmann::json config{};
-            auto&          exe = config["execution"];
-            exe["tolerance"]   = execution.numericalTolerance;
-            exe["parallel"]    = execution.parallel;
-            if (execution.parallel) {
-                exe["nthreads"] = execution.nthreads;
-            } else {
-                exe["nthreads"] = 1U;
-            }
-            exe["run_construction_checker"] = execution.runConstructionChecker;
-            exe["run_simulation_checker"]   = execution.runSimulationChecker;
-            exe["run_alternating_checker"]  = execution.runAlternatingChecker;
-            exe["run_zx_checker"]           = execution.runZXChecker;
-            if (execution.timeout > 0s) {
-                exe["timeout"] = execution.timeout.count();
-            }
-            auto& opt                                   = config["optimizations"];
-            opt["fix_output_permutation_mismatch"]      = optimizations.fixOutputPermutationMismatch;
-            opt["fuse_consecutive_single_qubit_gates"]  = optimizations.fuseSingleQubitGates;
-            opt["reconstruct_swaps"]                    = optimizations.reconstructSWAPs;
-            opt["remove_diagonal_gates_before_measure"] = optimizations.removeDiagonalGatesBeforeMeasure;
-            opt["transform_dynamic_circuit"]            = optimizations.transformDynamicCircuit;
-            opt["reorder_operations"]                   = optimizations.reorderOperations;
+  [[nodiscard]] nlohmann::json json() const {
+    nlohmann::json config{};
+    auto&          exe = config["execution"];
+    exe["tolerance"]   = execution.numericalTolerance;
+    exe["parallel"]    = execution.parallel;
+    if (execution.parallel) {
+      exe["nthreads"] = execution.nthreads;
+    } else {
+      exe["nthreads"] = 1U;
+    }
+    exe["run_construction_checker"] = execution.runConstructionChecker;
+    exe["run_simulation_checker"]   = execution.runSimulationChecker;
+    exe["run_alternating_checker"]  = execution.runAlternatingChecker;
+    exe["run_zx_checker"]           = execution.runZXChecker;
+    if (execution.timeout > 0s) {
+      exe["timeout"] = execution.timeout.count();
+    }
+    auto& opt = config["optimizations"];
+    opt["fix_output_permutation_mismatch"] =
+        optimizations.fixOutputPermutationMismatch;
+    opt["fuse_consecutive_single_qubit_gates"] =
+        optimizations.fuseSingleQubitGates;
+    opt["reconstruct_swaps"] = optimizations.reconstructSWAPs;
+    opt["remove_diagonal_gates_before_measure"] =
+        optimizations.removeDiagonalGatesBeforeMeasure;
+    opt["transform_dynamic_circuit"] = optimizations.transformDynamicCircuit;
+    opt["reorder_operations"]        = optimizations.reorderOperations;
 
-            auto& app = config["application"];
-            if (execution.runConstructionChecker) {
-                app["construction"] = ec::toString(application.constructionScheme);
-            }
-            if (execution.runSimulationChecker) {
-                app["simulation"] = ec::toString(application.simulationScheme);
-            }
-            if (execution.runAlternatingChecker) {
-                app["alternating"] = ec::toString(application.alternatingScheme);
-            }
-            if ((application.constructionScheme == ApplicationSchemeType::GateCost) ||
-                (application.simulationScheme == ApplicationSchemeType::GateCost) ||
-                (application.alternatingScheme == ApplicationSchemeType::GateCost)) {
-                if (!application.profile.empty()) {
-                    app["profile"] = application.profile;
-                } else {
-                    app["profile"] = "cost_function";
-                }
-            }
+    auto& app = config["application"];
+    if (execution.runConstructionChecker) {
+      app["construction"] = ec::toString(application.constructionScheme);
+    }
+    if (execution.runSimulationChecker) {
+      app["simulation"] = ec::toString(application.simulationScheme);
+    }
+    if (execution.runAlternatingChecker) {
+      app["alternating"] = ec::toString(application.alternatingScheme);
+    }
+    if ((application.constructionScheme == ApplicationSchemeType::GateCost) ||
+        (application.simulationScheme == ApplicationSchemeType::GateCost) ||
+        (application.alternatingScheme == ApplicationSchemeType::GateCost)) {
+      if (!application.profile.empty()) {
+        app["profile"] = application.profile;
+      } else {
+        app["profile"] = "cost_function";
+      }
+    }
 
-            if (execution.runConstructionChecker || execution.runAlternatingChecker) {
-                auto& fun              = config["functionality"];
-                fun["trace_threshold"] = functionality.traceThreshold;
-            }
+    if (execution.runConstructionChecker || execution.runAlternatingChecker) {
+      auto& fun              = config["functionality"];
+      fun["trace_threshold"] = functionality.traceThreshold;
+    }
 
-            if (execution.runSimulationChecker) {
-                auto& sim                          = config["simulation"];
-                sim["fidelity_threshold"]          = simulation.fidelityThreshold;
-                sim["max_sims"]                    = simulation.maxSims;
-                sim["state_type"]                  = ec::toString(simulation.stateType);
-                sim["seed"]                        = simulation.seed;
-                sim["store_counterexample_input"]  = simulation.storeCEXinput;
-                sim["store_counterexample_output"] = simulation.storeCEXoutput;
-            }
+    if (execution.runSimulationChecker) {
+      auto& sim                          = config["simulation"];
+      sim["fidelity_threshold"]          = simulation.fidelityThreshold;
+      sim["max_sims"]                    = simulation.maxSims;
+      sim["state_type"]                  = ec::toString(simulation.stateType);
+      sim["seed"]                        = simulation.seed;
+      sim["store_counterexample_input"]  = simulation.storeCEXinput;
+      sim["store_counterexample_output"] = simulation.storeCEXoutput;
+    }
 
-            return config;
-        }
+    return config;
+  }
 
-        [[nodiscard]] std::string toString() const {
-            constexpr auto indent = 2U;
-            return json().dump(indent);
-        }
-    };
+  [[nodiscard]] std::string toString() const {
+    constexpr auto indent = 2U;
+    return json().dump(indent);
+  }
+};
 } // namespace ec

--- a/include/EquivalenceCheckingManager.hpp
+++ b/include/EquivalenceCheckingManager.hpp
@@ -1,6 +1,6 @@
 //
-// This file is part of MQT QCEC library which is released under the MIT license.
-// See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
 #pragma once
@@ -25,201 +25,253 @@
 
 namespace ec {
 
-    class EquivalenceCheckingManager {
-    public:
-        struct Results {
-            double preprocessingTime{};
-            double checkTime{};
+class EquivalenceCheckingManager {
+public:
+  struct Results {
+    double preprocessingTime{};
+    double checkTime{};
 
-            EquivalenceCriterion equivalence = EquivalenceCriterion::NoInformation;
+    EquivalenceCriterion equivalence = EquivalenceCriterion::NoInformation;
 
-            std::size_t startedSimulations   = 0U;
-            std::size_t performedSimulations = 0U;
-            dd::CVec    cexInput{};
-            dd::CVec    cexOutput1{};
-            dd::CVec    cexOutput2{};
+    std::size_t startedSimulations   = 0U;
+    std::size_t performedSimulations = 0U;
+    dd::CVec    cexInput{};
+    dd::CVec    cexOutput1{};
+    dd::CVec    cexOutput2{};
 
-            [[nodiscard]] bool consideredEquivalent() const {
-                switch (equivalence) {
-                    case EquivalenceCriterion::Equivalent:
-                    case EquivalenceCriterion::ProbablyEquivalent:
-                    case EquivalenceCriterion::EquivalentUpToGlobalPhase:
-                    case EquivalenceCriterion::EquivalentUpToPhase:
-                        return true;
-                    default:
-                        return false;
-                }
-            }
+    [[nodiscard]] bool consideredEquivalent() const {
+      switch (equivalence) {
+      case EquivalenceCriterion::Equivalent:
+      case EquivalenceCriterion::ProbablyEquivalent:
+      case EquivalenceCriterion::EquivalentUpToGlobalPhase:
+      case EquivalenceCriterion::EquivalentUpToPhase:
+        return true;
+      default:
+        return false;
+      }
+    }
 
-            [[nodiscard]] nlohmann::json json() const;
+    [[nodiscard]] nlohmann::json json() const;
 
-            static void toJson(nlohmann::json& j, const dd::CVec& stateVector) {
-                j = nlohmann::json::array();
-                for (const auto& amp: stateVector) {
-                    j.emplace_back(std::pair{amp.real(), amp.imag()});
-                }
-            }
-            [[nodiscard]] std::string toString() const {
-                return json().dump(2);
-            }
-        };
+    static void toJson(nlohmann::json& j, const dd::CVec& stateVector) {
+      j = nlohmann::json::array();
+      for (const auto& amp : stateVector) {
+        j.emplace_back(std::pair{amp.real(), amp.imag()});
+      }
+    }
+    [[nodiscard]] std::string toString() const { return json().dump(2); }
+  };
 
-        EquivalenceCheckingManager(const qc::QuantumComputation& qc1, const qc::QuantumComputation& qc2, const Configuration& configuration = Configuration{});
+  EquivalenceCheckingManager(
+      const qc::QuantumComputation& qc1, const qc::QuantumComputation& qc2,
+      const Configuration& configuration = Configuration{});
 
-        void run();
+  void run();
 
-        void reset() {
-            stateGenerator.clear();
-            results = Results{};
-            checkers.clear();
-        }
+  void reset() {
+    stateGenerator.clear();
+    results = Results{};
+    checkers.clear();
+  }
 
-        [[nodiscard]] nlohmann::json json() const;
-        [[nodiscard]] std::string    toString() const { return json().dump(2); }
-        friend std::ostream&         operator<<(std::ostream& os, const EquivalenceCheckingManager& ecm) { return os << ecm.toString(); }
+  [[nodiscard]] nlohmann::json json() const;
+  [[nodiscard]] std::string    toString() const { return json().dump(2); }
 
-        [[nodiscard]] EquivalenceCriterion equivalence() const {
-            return results.equivalence;
-        }
-        [[nodiscard]] Configuration getConfiguration() const { return configuration; }
-        [[nodiscard]] Results       getResults() const { return results; }
+  friend std::ostream& operator<<(std::ostream&                     os,
+                                  const EquivalenceCheckingManager& ecm) {
+    return os << ecm.toString();
+  }
 
-        // convenience functions for changing the configuration after the manager has been constructed:
-        // Execution: These settings may be changed to influence what is executed during `run`
-        void setTolerance(dd::fp tol) {
-            configuration.execution.numericalTolerance = tol;
-            dd::ComplexTable<>::setTolerance(tol);
-        }
-        void setParallel(bool parallel) { configuration.execution.parallel = parallel; }
-        void setNThreads(std::size_t nthreads) { configuration.execution.nthreads = nthreads; }
-        void setTimeout(std::chrono::seconds timeout) { configuration.execution.timeout = timeout; }
-        void setConstructionChecker(bool run) { configuration.execution.runConstructionChecker = run; }
-        void setSimulationChecker(bool run) { configuration.execution.runSimulationChecker = run; }
-        void setAlternatingChecker(bool run) { configuration.execution.runAlternatingChecker = run; }
-        void setZXChecker(bool run) { configuration.execution.runZXChecker = run; }
+  [[nodiscard]] EquivalenceCriterion equivalence() const {
+    return results.equivalence;
+  }
+  [[nodiscard]] Configuration getConfiguration() const { return configuration; }
+  [[nodiscard]] Results       getResults() const { return results; }
 
-        // Optimization: Optimizations are applied during initialization. Already configured and applied optimizations cannot be reverted
-        void runFixOutputPermutationMismatch();
-        void fuseSingleQubitGates();
-        void reconstructSWAPs();
-        void reorderOperations();
+  // convenience functions for changing the configuration after the manager has
+  // been constructed: Execution: These settings may be changed to influence
+  // what is executed during `run`
+  void setTolerance(dd::fp tol) {
+    configuration.execution.numericalTolerance = tol;
+    dd::ComplexTable<>::setTolerance(tol);
+  }
+  void setParallel(bool parallel) {
+    configuration.execution.parallel = parallel;
+  }
+  void setNThreads(std::size_t nthreads) {
+    configuration.execution.nthreads = nthreads;
+  }
+  void setTimeout(std::chrono::seconds timeout) {
+    configuration.execution.timeout = timeout;
+  }
+  void setConstructionChecker(bool run) {
+    configuration.execution.runConstructionChecker = run;
+  }
+  void setSimulationChecker(bool run) {
+    configuration.execution.runSimulationChecker = run;
+  }
+  void setAlternatingChecker(bool run) {
+    configuration.execution.runAlternatingChecker = run;
+  }
+  void setZXChecker(bool run) { configuration.execution.runZXChecker = run; }
 
-        // Application: These settings may be changed to influence the sequence in which gates are applied during the equivalence check
-        void setConstructionApplicationScheme(const ApplicationSchemeType applicationScheme) { configuration.application.constructionScheme = applicationScheme; }
-        void setSimulationApplicationScheme(const ApplicationSchemeType applicationScheme) { configuration.application.simulationScheme = applicationScheme; }
-        void setAlternatingApplicationScheme(const ApplicationSchemeType applicationScheme) { configuration.application.alternatingScheme = applicationScheme; }
-        void setApplicationScheme(const ApplicationSchemeType applicationScheme) {
-            setConstructionApplicationScheme(applicationScheme);
-            setSimulationApplicationScheme(applicationScheme);
-            setAlternatingApplicationScheme(applicationScheme);
-        }
-        void setConstructionGateCostProfile(std::string_view profileLocation) {
-            configuration.application.constructionScheme = ApplicationSchemeType::GateCost;
-            configuration.application.profile            = profileLocation;
-        }
-        void setSimulationGateCostProfile(std::string_view profileLocation) {
-            configuration.application.simulationScheme = ApplicationSchemeType::GateCost;
-            configuration.application.profile          = profileLocation;
-        }
-        void setAlternatingGateCostProfile(std::string_view profileLocation) {
-            configuration.application.alternatingScheme = ApplicationSchemeType::GateCost;
-            configuration.application.profile           = profileLocation;
-        }
-        void setGateCostProfile(std::string_view profileLocation) {
-            setConstructionGateCostProfile(profileLocation);
-            setSimulationGateCostProfile(profileLocation);
-            setAlternatingGateCostProfile(profileLocation);
-        }
-        void setConstructionGateCostFunction(const CostFunction& costFunction) {
-            configuration.application.constructionScheme = ApplicationSchemeType::GateCost;
-            configuration.application.costFunction       = costFunction;
-        }
-        void setSimulationGateCostFunction(const CostFunction& costFunction) {
-            configuration.application.simulationScheme = ApplicationSchemeType::GateCost;
-            configuration.application.costFunction     = costFunction;
-        }
-        void setAlternatingGateCostFunction(const CostFunction& costFunction) {
-            configuration.application.alternatingScheme = ApplicationSchemeType::GateCost;
-            configuration.application.costFunction      = costFunction;
-        }
-        void setGateCostFunction(const CostFunction& costFunction) {
-            setConstructionGateCostFunction(costFunction);
-            setSimulationGateCostFunction(costFunction);
-            setAlternatingGateCostFunction(costFunction);
-        }
-        // Functionality: These settings may be changed to adjust options for checkers considering the whole functionality
-        void setTraceThreshold(double traceThreshold) { configuration.functionality.traceThreshold = traceThreshold; }
+  // Optimization: Optimizations are applied during initialization. Already
+  // configured and applied optimizations cannot be reverted
+  void runFixOutputPermutationMismatch();
+  void fuseSingleQubitGates();
+  void reconstructSWAPs();
+  void reorderOperations();
 
-        // Simulation: These setting may be changed to adjust the kinds of simulations that are performed
-        void setFidelityThreshold(double fidelityThreshold) { configuration.simulation.fidelityThreshold = fidelityThreshold; }
-        void setMaxSims(std::size_t sims) {
-            if (sims == 0U) {
-                configuration.execution.runSimulationChecker = false;
-            }
-            configuration.simulation.maxSims = sims;
-        }
-        void setStateType(StateType stateType) { configuration.simulation.stateType = stateType; }
-        void setSeed(std::size_t seed) {
-            configuration.simulation.seed = seed;
-            stateGenerator.seedGenerator(seed);
-        }
-        void storeCEXinput(bool store) { configuration.simulation.storeCEXinput = store; }
-        void storeCEXoutput(bool store) { configuration.simulation.storeCEXoutput = store; }
+  // Application: These settings may be changed to influence the sequence in
+  // which gates are applied during the equivalence check
+  void setConstructionApplicationScheme(
+      const ApplicationSchemeType applicationScheme) {
+    configuration.application.constructionScheme = applicationScheme;
+  }
+  void setSimulationApplicationScheme(
+      const ApplicationSchemeType applicationScheme) {
+    configuration.application.simulationScheme = applicationScheme;
+  }
+  void setAlternatingApplicationScheme(
+      const ApplicationSchemeType applicationScheme) {
+    configuration.application.alternatingScheme = applicationScheme;
+  }
+  void setApplicationScheme(const ApplicationSchemeType applicationScheme) {
+    setConstructionApplicationScheme(applicationScheme);
+    setSimulationApplicationScheme(applicationScheme);
+    setAlternatingApplicationScheme(applicationScheme);
+  }
+  void setConstructionGateCostProfile(std::string_view profileLocation) {
+    configuration.application.constructionScheme =
+        ApplicationSchemeType::GateCost;
+    configuration.application.profile = profileLocation;
+  }
+  void setSimulationGateCostProfile(std::string_view profileLocation) {
+    configuration.application.simulationScheme =
+        ApplicationSchemeType::GateCost;
+    configuration.application.profile = profileLocation;
+  }
+  void setAlternatingGateCostProfile(std::string_view profileLocation) {
+    configuration.application.alternatingScheme =
+        ApplicationSchemeType::GateCost;
+    configuration.application.profile = profileLocation;
+  }
+  void setGateCostProfile(std::string_view profileLocation) {
+    setConstructionGateCostProfile(profileLocation);
+    setSimulationGateCostProfile(profileLocation);
+    setAlternatingGateCostProfile(profileLocation);
+  }
+  void setConstructionGateCostFunction(const CostFunction& costFunction) {
+    configuration.application.constructionScheme =
+        ApplicationSchemeType::GateCost;
+    configuration.application.costFunction = costFunction;
+  }
+  void setSimulationGateCostFunction(const CostFunction& costFunction) {
+    configuration.application.simulationScheme =
+        ApplicationSchemeType::GateCost;
+    configuration.application.costFunction = costFunction;
+  }
+  void setAlternatingGateCostFunction(const CostFunction& costFunction) {
+    configuration.application.alternatingScheme =
+        ApplicationSchemeType::GateCost;
+    configuration.application.costFunction = costFunction;
+  }
+  void setGateCostFunction(const CostFunction& costFunction) {
+    setConstructionGateCostFunction(costFunction);
+    setSimulationGateCostFunction(costFunction);
+    setAlternatingGateCostFunction(costFunction);
+  }
+  // Functionality: These settings may be changed to adjust options for checkers
+  // considering the whole functionality
+  void setTraceThreshold(double traceThreshold) {
+    configuration.functionality.traceThreshold = traceThreshold;
+  }
 
-    protected:
-        qc::QuantumComputation qc1{};
-        qc::QuantumComputation qc2{};
+  // Simulation: These setting may be changed to adjust the kinds of simulations
+  // that are performed
+  void setFidelityThreshold(double fidelityThreshold) {
+    configuration.simulation.fidelityThreshold = fidelityThreshold;
+  }
+  void setMaxSims(std::size_t sims) {
+    if (sims == 0U) {
+      configuration.execution.runSimulationChecker = false;
+    }
+    configuration.simulation.maxSims = sims;
+  }
+  void setStateType(StateType stateType) {
+    configuration.simulation.stateType = stateType;
+  }
+  void setSeed(std::size_t seed) {
+    configuration.simulation.seed = seed;
+    stateGenerator.seedGenerator(seed);
+  }
+  void storeCEXinput(bool store) {
+    configuration.simulation.storeCEXinput = store;
+  }
+  void storeCEXoutput(bool store) {
+    configuration.simulation.storeCEXoutput = store;
+  }
 
-        Configuration configuration{};
+protected:
+  qc::QuantumComputation qc1{};
+  qc::QuantumComputation qc2{};
 
-        StateGenerator stateGenerator;
-        std::mutex     stateGeneratorMutex{};
+  Configuration configuration{};
 
-        bool                                             done{false};
-        std::condition_variable                          doneCond{};
-        std::mutex                                       doneMutex{};
-        std::vector<std::unique_ptr<EquivalenceChecker>> checkers{};
+  StateGenerator stateGenerator;
+  std::mutex     stateGeneratorMutex{};
 
-        Results results{};
+  bool                                             done{false};
+  std::condition_variable                          doneCond{};
+  std::mutex                                       doneMutex{};
+  std::vector<std::unique_ptr<EquivalenceChecker>> checkers{};
 
-        /// Given that one circuit has more qubits than the other, the difference is assumed to arise from ancillary qubits.
-        /// This function changes the additional qubits in the larger circuit to ancillary qubits.
-        /// Furthermore it adds corresponding ancillaries in the smaller circuit
-        void setupAncillariesAndGarbage();
+  Results results{};
 
-        /// In some cases both circuits calculate the same function, but on different qubits.
-        /// This function tries to correct such mismatches.
-        /// Note that this is still highly experimental!
-        void fixOutputPermutationMismatch();
+  /// Given that one circuit has more qubits than the other, the difference is
+  /// assumed to arise from ancillary qubits. This function changes the
+  /// additional qubits in the larger circuit to ancillary qubits. Furthermore
+  /// it adds corresponding ancillaries in the smaller circuit
+  void setupAncillariesAndGarbage();
 
-        /// Run all configured optimization passes
-        void runOptimizationPasses();
+  /// In some cases both circuits calculate the same function, but on different
+  /// qubits. This function tries to correct such mismatches. Note that this is
+  /// still highly experimental!
+  void fixOutputPermutationMismatch();
 
-        /// Sequential Equivalence Check (TCAD'21)
-        /// First, a couple of simulations with various stimuli are conducted.
-        /// If any of those stimuli produce output states with a fidelity not close to 1, the non-equivalence has been shown and the check is finished.
-        /// Given that a couple of simulations did not show any signs of non-equivalence, the circuits are probably equivalent.
-        /// To assure this, the alternating decision diagram checker is invoked to determine the equivalence.
-        void checkSequential();
+  /// Run all configured optimization passes
+  void runOptimizationPasses();
 
-        /// Parallel Equivalence Check
-        /// The parallel flow makes use of the available processing power by orchestrating all configured checks in a parallel fashion
-        void checkParallel();
+  /// Sequential Equivalence Check (TCAD'21)
+  /// First, a couple of simulations with various stimuli are conducted.
+  /// If any of those stimuli produce output states with a fidelity not close to
+  /// 1, the non-equivalence has been shown and the check is finished. Given
+  /// that a couple of simulations did not show any signs of non-equivalence,
+  /// the circuits are probably equivalent. To assure this, the alternating
+  /// decision diagram checker is invoked to determine the equivalence.
+  void checkSequential();
 
-        /// Signal all checker that they shall abort the computation as soon as possible since a result has been determined
-        void setAndSignalDone() {
-            done = true;
-            for (const auto& checker: checkers) {
-                if (checker) {
-                    checker->signalDone();
-                }
-            }
-        }
+  /// Parallel Equivalence Check
+  /// The parallel flow makes use of the available processing power by
+  /// orchestrating all configured checks in a parallel fashion
+  void checkParallel();
 
-        static void addCircuitDescription(const qc::QuantumComputation& qc, nlohmann::json& j) {
-            j["name"]     = qc.getName();
-            j["n_qubits"] = qc.getNqubits();
-            j["n_gates"]  = qc.getNops();
-        }
-    };
+  /// Signal all checker that they shall abort the computation as soon as
+  /// possible since a result has been determined
+  void setAndSignalDone() {
+    done = true;
+    for (const auto& checker : checkers) {
+      if (checker) {
+        checker->signalDone();
+      }
+    }
+  }
+
+  static void addCircuitDescription(const qc::QuantumComputation& qc,
+                                    nlohmann::json&               j) {
+    j["name"]     = qc.getName();
+    j["n_qubits"] = qc.getNqubits();
+    j["n_gates"]  = qc.getNops();
+  }
+};
 } // namespace ec

--- a/include/EquivalenceCriterion.hpp
+++ b/include/EquivalenceCriterion.hpp
@@ -1,6 +1,6 @@
 //
-// This file is part of MQT QCEC library which is released under the MIT license.
-// See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
 #pragma once
@@ -9,76 +9,79 @@
 #include <iostream>
 
 namespace ec {
-    enum class EquivalenceCriterion {
-        NotEquivalent             = 0,
-        Equivalent                = 1,
-        NoInformation             = 2,
-        ProbablyEquivalent        = 3,
-        EquivalentUpToGlobalPhase = 4,
-        EquivalentUpToPhase       = 5,
-        ProbablyNotEquivalent     = 6
-    };
+enum class EquivalenceCriterion {
+  NotEquivalent             = 0,
+  Equivalent                = 1,
+  NoInformation             = 2,
+  ProbablyEquivalent        = 3,
+  EquivalentUpToGlobalPhase = 4,
+  EquivalentUpToPhase       = 5,
+  ProbablyNotEquivalent     = 6
+};
 
-    inline std::string toString(const EquivalenceCriterion& criterion) noexcept {
-        switch (criterion) {
-            case EquivalenceCriterion::NotEquivalent:
-                return "not_equivalent";
-            case EquivalenceCriterion::Equivalent:
-                return "equivalent";
-            case EquivalenceCriterion::ProbablyEquivalent:
-                return "probably_equivalent";
-            case EquivalenceCriterion::EquivalentUpToGlobalPhase:
-                return "equivalent_up_to_global_phase";
-            case EquivalenceCriterion::EquivalentUpToPhase:
-                return "equivalent_up_to_phase";
-            case EquivalenceCriterion::ProbablyNotEquivalent:
-                return "probably_not_equivalent";
-            default:
-                return "no_information";
-        }
-    }
+inline std::string toString(const EquivalenceCriterion& criterion) noexcept {
+  switch (criterion) {
+  case EquivalenceCriterion::NotEquivalent:
+    return "not_equivalent";
+  case EquivalenceCriterion::Equivalent:
+    return "equivalent";
+  case EquivalenceCriterion::ProbablyEquivalent:
+    return "probably_equivalent";
+  case EquivalenceCriterion::EquivalentUpToGlobalPhase:
+    return "equivalent_up_to_global_phase";
+  case EquivalenceCriterion::EquivalentUpToPhase:
+    return "equivalent_up_to_phase";
+  case EquivalenceCriterion::ProbablyNotEquivalent:
+    return "probably_not_equivalent";
+  default:
+    return "no_information";
+  }
+}
 
-    inline EquivalenceCriterion fromString(const std::string& criterion) noexcept {
-        if ((criterion == "not_equivalent") || (criterion == "0")) {
-            return EquivalenceCriterion::NotEquivalent;
-        }
-        if ((criterion == "equivalent") || (criterion == "1")) {
-            return EquivalenceCriterion::Equivalent;
-        }
-        if ((criterion == "probably_equivalent") || (criterion == "2")) {
-            return EquivalenceCriterion::ProbablyEquivalent;
-        }
-        if ((criterion == "equivalent_up_to_global_phase") || (criterion == "3")) {
-            return EquivalenceCriterion::EquivalentUpToGlobalPhase;
-        }
-        if ((criterion == "equivalent_up_to_phase") || (criterion == "4")) {
-            return EquivalenceCriterion::EquivalentUpToPhase;
-        }
-        if ((criterion == "no_information") || (criterion == "5")) {
-            return EquivalenceCriterion::NoInformation;
-        }
-        if ((criterion == "probably_not_equivalent") || (criterion == "6")) {
-            return EquivalenceCriterion::ProbablyNotEquivalent;
-        }
-        std::cerr << "Unknown equivalence criterion: " << criterion << ". Defaulting to `no_information`.\n";
-        return EquivalenceCriterion::NoInformation;
-    }
+inline EquivalenceCriterion fromString(const std::string& criterion) noexcept {
+  if ((criterion == "not_equivalent") || (criterion == "0")) {
+    return EquivalenceCriterion::NotEquivalent;
+  }
+  if ((criterion == "equivalent") || (criterion == "1")) {
+    return EquivalenceCriterion::Equivalent;
+  }
+  if ((criterion == "probably_equivalent") || (criterion == "2")) {
+    return EquivalenceCriterion::ProbablyEquivalent;
+  }
+  if ((criterion == "equivalent_up_to_global_phase") || (criterion == "3")) {
+    return EquivalenceCriterion::EquivalentUpToGlobalPhase;
+  }
+  if ((criterion == "equivalent_up_to_phase") || (criterion == "4")) {
+    return EquivalenceCriterion::EquivalentUpToPhase;
+  }
+  if ((criterion == "no_information") || (criterion == "5")) {
+    return EquivalenceCriterion::NoInformation;
+  }
+  if ((criterion == "probably_not_equivalent") || (criterion == "6")) {
+    return EquivalenceCriterion::ProbablyNotEquivalent;
+  }
+  std::cerr << "Unknown equivalence criterion: " << criterion
+            << ". Defaulting to `no_information`.\n";
+  return EquivalenceCriterion::NoInformation;
+}
 
-    inline std::istream& operator>>(std::istream& in, EquivalenceCriterion& criterion) {
-        std::string token;
-        in >> token;
+inline std::istream& operator>>(std::istream&         in,
+                                EquivalenceCriterion& criterion) {
+  std::string token;
+  in >> token;
 
-        if (token.empty()) {
-            in.setstate(std::istream::failbit);
-            return in;
-        }
+  if (token.empty()) {
+    in.setstate(std::istream::failbit);
+    return in;
+  }
 
-        criterion = fromString(token);
-        return in;
-    }
+  criterion = fromString(token);
+  return in;
+}
 
-    inline std::ostream& operator<<(std::ostream& out, const EquivalenceCriterion& criterion) {
-        out << toString(criterion);
-        return out;
-    }
+inline std::ostream& operator<<(std::ostream&               out,
+                                const EquivalenceCriterion& criterion) {
+  out << toString(criterion);
+  return out;
+}
 } // namespace ec

--- a/include/ThreadSafeQueue.hpp
+++ b/include/ThreadSafeQueue.hpp
@@ -1,6 +1,6 @@
 //
-// This file is part of MQT QCEC library which is released under the MIT license.
-// See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
 #pragma once
@@ -11,93 +11,93 @@
 #include <mutex>
 
 namespace ec {
-    template<typename T>
-    class ThreadSafeQueue {
-    public:
-        ThreadSafeQueue():
-            tail(head.get()) {}
+template <typename T> class ThreadSafeQueue {
+public:
+  ThreadSafeQueue() : tail(head.get()) {}
 
-        ThreadSafeQueue(const ThreadSafeQueue& other) = delete;
+  ThreadSafeQueue(const ThreadSafeQueue& other) = delete;
 
-        ThreadSafeQueue& operator=(const ThreadSafeQueue& other) = delete;
+  ThreadSafeQueue& operator=(const ThreadSafeQueue& other) = delete;
 
-        std::shared_ptr<T> waitAndPop() {
-            auto const oldHead = waitPopHead();
-            return oldHead->data;
-        }
+  std::shared_ptr<T> waitAndPop() {
+    auto const oldHead = waitPopHead();
+    return oldHead->data;
+  }
 
-        template<typename Clock, typename Dur>
-        std::shared_ptr<T> waitAndPopUntil(const std::chrono::time_point<Clock, Dur>& timepoint) {
-            if (const auto oldHead = waitPopHeadUntil(timepoint)) {
-                return oldHead->data;
-            }
-            return nullptr;
-        }
+  template <typename Clock, typename Dur>
+  std::shared_ptr<T>
+  waitAndPopUntil(const std::chrono::time_point<Clock, Dur>& timepoint) {
+    if (const auto oldHead = waitPopHeadUntil(timepoint)) {
+      return oldHead->data;
+    }
+    return nullptr;
+  }
 
-        void push(T value) {
-            auto data(std::make_shared<T>(std::move(value)));
-            auto p = std::make_unique<Node>();
-            {
-                const std::lock_guard tailLock(tailMutex);
-                tail->data          = data;
-                Node* const newTail = p.get();
-                tail->next          = std::move(p);
-                tail                = newTail;
-            }
-            dataCond.notify_one();
-        }
-        [[nodiscard]] bool empty() {
-            const std::lock_guard headLock(headMutex);
-            return head.get() == getTail();
-        }
+  void push(T value) {
+    auto data(std::make_shared<T>(std::move(value)));
+    auto p = std::make_unique<Node>();
+    {
+      const std::lock_guard tailLock(tailMutex);
+      tail->data          = data;
+      Node* const newTail = p.get();
+      tail->next          = std::move(p);
+      tail                = newTail;
+    }
+    dataCond.notify_one();
+  }
+  [[nodiscard]] bool empty() {
+    const std::lock_guard headLock(headMutex);
+    return head.get() == getTail();
+  }
 
-    private:
-        struct Node {
-            std::shared_ptr<T>    data;
-            std::unique_ptr<Node> next;
-        };
-        std::mutex              headMutex;
-        std::unique_ptr<Node>   head = std::make_unique<Node>();
-        std::mutex              tailMutex;
-        Node*                   tail;
-        std::condition_variable dataCond;
+private:
+  struct Node {
+    std::shared_ptr<T>    data;
+    std::unique_ptr<Node> next;
+  };
+  std::mutex              headMutex;
+  std::unique_ptr<Node>   head = std::make_unique<Node>();
+  std::mutex              tailMutex;
+  Node*                   tail;
+  std::condition_variable dataCond;
 
-        auto getTail() {
-            const std::lock_guard tailLock(tailMutex);
-            return tail;
-        }
+  auto getTail() {
+    const std::lock_guard tailLock(tailMutex);
+    return tail;
+  }
 
-        auto popHead() {
-            auto oldHead = std::move(head);
-            head         = std::move(oldHead->next);
-            return oldHead;
-        }
+  auto popHead() {
+    auto oldHead = std::move(head);
+    head         = std::move(oldHead->next);
+    return oldHead;
+  }
 
-        auto waitForData() {
-            std::unique_lock headLock(headMutex);
-            dataCond.wait(headLock, [this] { return head.get() != getTail(); });
-            return headLock;
-        }
+  auto waitForData() {
+    std::unique_lock headLock(headMutex);
+    dataCond.wait(headLock, [this] { return head.get() != getTail(); });
+    return headLock;
+  }
 
-        template<typename Clock, typename Dur>
-        auto waitForDataUntil(const std::chrono::time_point<Clock, Dur>& timepoint) {
-            std::unique_lock headLock(headMutex);
-            dataCond.wait_until(headLock, timepoint, [this] { return head.get() != getTail(); });
-            return headLock;
-        }
+  template <typename Clock, typename Dur>
+  auto waitForDataUntil(const std::chrono::time_point<Clock, Dur>& timepoint) {
+    std::unique_lock headLock(headMutex);
+    dataCond.wait_until(headLock, timepoint,
+                        [this] { return head.get() != getTail(); });
+    return headLock;
+  }
 
-        auto waitPopHead() {
-            [[maybe_unused]] auto headLock(waitForData());
-            return popHead();
-        }
+  auto waitPopHead() {
+    [[maybe_unused]] auto headLock(waitForData());
+    return popHead();
+  }
 
-        template<typename Clock, typename Dur>
-        auto waitPopHeadUntil(const std::chrono::time_point<Clock, Dur>& timepoint) {
-            [[maybe_unused]] auto headLock(waitForDataUntil(timepoint));
-            if (head.get() == getTail()) {
-                return std::unique_ptr<Node>();
-            }
-            return popHead();
-        }
-    };
+  template <typename Clock, typename Dur>
+  auto waitPopHeadUntil(const std::chrono::time_point<Clock, Dur>& timepoint) {
+    [[maybe_unused]] auto headLock(waitForDataUntil(timepoint));
+    if (head.get() == getTail()) {
+      return std::unique_ptr<Node>();
+    }
+    return popHead();
+  }
+};
 } // namespace ec

--- a/include/checker/EquivalenceChecker.hpp
+++ b/include/checker/EquivalenceChecker.hpp
@@ -1,6 +1,6 @@
 //
-// This file is part of MQT QCEC library which is released under the MIT license.
-// See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
 #pragma once
@@ -13,50 +13,50 @@
 #include <utility>
 
 namespace ec {
-    class EquivalenceChecker {
-    public:
-        EquivalenceChecker(const qc::QuantumComputation& qc1, const qc::QuantumComputation& qc2, Configuration configuration) noexcept:
-            qc1(qc1), qc2(qc2),
-            nqubits(std::max(qc1.getNqubits(), qc2.getNqubits())),
-            configuration(std::move(configuration)){};
+class EquivalenceChecker {
+public:
+  EquivalenceChecker(const qc::QuantumComputation& qc1,
+                     const qc::QuantumComputation& qc2,
+                     Configuration                 configuration) noexcept
+      : qc1(qc1), qc2(qc2),
+        nqubits(std::max(qc1.getNqubits(), qc2.getNqubits())),
+        configuration(std::move(configuration)){};
 
-        virtual ~EquivalenceChecker() = default;
+  virtual ~EquivalenceChecker() = default;
 
-        virtual EquivalenceCriterion run() = 0;
+  virtual EquivalenceCriterion run() = 0;
 
-        [[nodiscard]] const Configuration& getConfiguration() const noexcept {
-            return configuration;
-        }
-        [[nodiscard]] EquivalenceCriterion getEquivalence() const noexcept {
-            return equivalence;
-        }
-        [[nodiscard]] double getRuntime() const noexcept {
-            return runtime;
-        }
+  [[nodiscard]] const Configuration& getConfiguration() const noexcept {
+    return configuration;
+  }
+  [[nodiscard]] EquivalenceCriterion getEquivalence() const noexcept {
+    return equivalence;
+  }
+  [[nodiscard]] double getRuntime() const noexcept { return runtime; }
 
-        virtual void json(nlohmann::json& j) const noexcept {
-            j["equivalence"] = toString(equivalence);
-            j["runtime"]     = getRuntime();
-        }
+  virtual void json(nlohmann::json& j) const noexcept {
+    j["equivalence"] = toString(equivalence);
+    j["runtime"]     = getRuntime();
+  }
 
-        void signalDone() {
-            done.store(true, std::memory_order_relaxed);
-        }
-        [[nodiscard]] auto isDone() const { return done.load(std::memory_order_relaxed); }
+  void signalDone() { done.store(true, std::memory_order_relaxed); }
+  [[nodiscard]] auto isDone() const {
+    return done.load(std::memory_order_relaxed);
+  }
 
-    protected:
-        const qc::QuantumComputation& qc1;
-        const qc::QuantumComputation& qc2;
+protected:
+  const qc::QuantumComputation& qc1;
+  const qc::QuantumComputation& qc2;
 
-        dd::QubitCount nqubits{};
+  dd::QubitCount nqubits{};
 
-        Configuration configuration;
+  Configuration configuration;
 
-        EquivalenceCriterion equivalence = EquivalenceCriterion::NoInformation;
-        double               runtime{};
+  EquivalenceCriterion equivalence = EquivalenceCriterion::NoInformation;
+  double               runtime{};
 
-    private:
-        std::atomic<bool> done{false};
-    };
+private:
+  std::atomic<bool> done{false};
+};
 
 } // namespace ec

--- a/include/checker/dd/DDAlternatingChecker.hpp
+++ b/include/checker/dd/DDAlternatingChecker.hpp
@@ -1,6 +1,6 @@
 //
-// This file is part of MQT QCEC library which is released under the MIT license.
-// See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
 #pragma once
@@ -10,41 +10,51 @@
 #include "applicationscheme/LookaheadApplicationScheme.hpp"
 
 namespace ec {
-    class DDAlternatingChecker final: public DDEquivalenceChecker<qc::MatrixDD, AlternatingDDPackage> {
-    public:
-        DDAlternatingChecker(const qc::QuantumComputation& qc1, const qc::QuantumComputation& qc2, ec::Configuration configuration):
-            DDEquivalenceChecker(qc1, qc2, std::move(configuration)) {
-            // gates from the second circuit shall be applied "from the right"
-            taskManager2.flipDirection();
+class DDAlternatingChecker final
+    : public DDEquivalenceChecker<qc::MatrixDD, AlternatingDDPackage> {
+public:
+  DDAlternatingChecker(const qc::QuantumComputation& qc1,
+                       const qc::QuantumComputation& qc2,
+                       ec::Configuration             configuration)
+      : DDEquivalenceChecker(qc1, qc2, std::move(configuration)) {
+    // gates from the second circuit shall be applied "from the right"
+    taskManager2.flipDirection();
 
-            initializeApplicationScheme(this->configuration.application.alternatingScheme);
+    initializeApplicationScheme(
+        this->configuration.application.alternatingScheme);
 
-            // special treatment for the lookahead application scheme
-            if (auto* lookahead = dynamic_cast<LookaheadApplicationScheme<AlternatingDDPackage>*>(applicationScheme.get())) {
-                // initialize links for the internal state and the package of the lookahead scheme
-                lookahead->setInternalState(functionality);
-                lookahead->setPackage(dd.get());
-            }
-        }
+    // special treatment for the lookahead application scheme
+    if (auto* lookahead =
+            dynamic_cast<LookaheadApplicationScheme<AlternatingDDPackage>*>(
+                applicationScheme.get())) {
+      // initialize links for the internal state and the package of the
+      // lookahead scheme
+      lookahead->setInternalState(functionality);
+      lookahead->setPackage(dd.get());
+    }
+  }
 
-        void json(nlohmann::json& j) const noexcept override {
-            DDEquivalenceChecker::json(j);
-            j["checker"] = "decision_diagram_alternating";
-        }
+  void json(nlohmann::json& j) const noexcept override {
+    DDEquivalenceChecker::json(j);
+    j["checker"] = "decision_diagram_alternating";
+  }
 
-    private:
-        qc::MatrixDD functionality{};
+private:
+  qc::MatrixDD functionality{};
 
-        void initializeTask([[maybe_unused]] TaskManager<qc::MatrixDD, AlternatingDDPackage>& taskManager) override{
-            // task initialization is conducted separately for this checker
-        };
-        void                 initialize() override;
-        void                 execute() override;
-        void                 finish() override;
-        void                 postprocess() override;
-        EquivalenceCriterion checkEquivalence() override;
+  void initializeTask(
+      [[maybe_unused]] TaskManager<qc::MatrixDD, AlternatingDDPackage>&
+          taskManager) override{
+      // task initialization is conducted separately for this checker
+  };
+  void                 initialize() override;
+  void                 execute() override;
+  void                 finish() override;
+  void                 postprocess() override;
+  EquivalenceCriterion checkEquivalence() override;
 
-        // at some point this routine should probably make its way into the QFR library
-        [[nodiscard]] bool gatesAreIdentical() const;
-    };
+  // at some point this routine should probably make its way into the QFR
+  // library
+  [[nodiscard]] bool gatesAreIdentical() const;
+};
 } // namespace ec

--- a/include/checker/dd/DDConstructionChecker.hpp
+++ b/include/checker/dd/DDConstructionChecker.hpp
@@ -1,6 +1,6 @@
 //
-// This file is part of MQT QCEC library which is released under the MIT license.
-// See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
 #pragma once
@@ -9,27 +9,34 @@
 #include "DDPackageConfigs.hpp"
 
 namespace ec {
-    class DDConstructionChecker final: public DDEquivalenceChecker<qc::MatrixDD, ConstructionDDPackage> {
-    public:
-        DDConstructionChecker(const qc::QuantumComputation& qc1, const qc::QuantumComputation& qc2, ec::Configuration configuration):
-            DDEquivalenceChecker(qc1, qc2, std::move(configuration)) {
-            if (this->configuration.application.constructionScheme == ApplicationSchemeType::Lookahead) {
-                throw std::invalid_argument("Lookahead application scheme must not be used with DD construction checker.");
-            }
-            initializeApplicationScheme(this->configuration.application.constructionScheme);
-        }
+class DDConstructionChecker final
+    : public DDEquivalenceChecker<qc::MatrixDD, ConstructionDDPackage> {
+public:
+  DDConstructionChecker(const qc::QuantumComputation& qc1,
+                        const qc::QuantumComputation& qc2,
+                        ec::Configuration             configuration)
+      : DDEquivalenceChecker(qc1, qc2, std::move(configuration)) {
+    if (this->configuration.application.constructionScheme ==
+        ApplicationSchemeType::Lookahead) {
+      throw std::invalid_argument("Lookahead application scheme must not be "
+                                  "used with DD construction checker.");
+    }
+    initializeApplicationScheme(
+        this->configuration.application.constructionScheme);
+  }
 
-        void json(nlohmann::json& j) const noexcept override {
-            DDEquivalenceChecker::json(j);
-            j["checker"] = "decision_diagram_construction";
-        }
+  void json(nlohmann::json& j) const noexcept override {
+    DDEquivalenceChecker::json(j);
+    j["checker"] = "decision_diagram_construction";
+  }
 
-    private:
-        void initializeTask(TaskManager<qc::MatrixDD, ConstructionDDPackage>& taskManager) override {
-            const auto initial = dd->makeIdent(nqubits);
-            taskManager.setInternalState(initial);
-            taskManager.incRef();
-            taskManager.reduceAncillae();
-        }
-    };
+private:
+  void initializeTask(
+      TaskManager<qc::MatrixDD, ConstructionDDPackage>& taskManager) override {
+    const auto initial = dd->makeIdent(nqubits);
+    taskManager.setInternalState(initial);
+    taskManager.incRef();
+    taskManager.reduceAncillae();
+  }
+};
 } // namespace ec

--- a/include/checker/dd/DDEquivalenceChecker.hpp
+++ b/include/checker/dd/DDEquivalenceChecker.hpp
@@ -1,6 +1,6 @@
 //
-// This file is part of MQT QCEC library which is released under the MIT license.
-// See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
 #pragma once
@@ -16,40 +16,43 @@
 #include <utility>
 
 namespace ec {
-    template<class DDType, class DDPackage>
-    class DDEquivalenceChecker: public EquivalenceChecker {
-    public:
-        DDEquivalenceChecker(const qc::QuantumComputation& qc1, const qc::QuantumComputation& qc2, Configuration configuration) noexcept;
+template <class DDType, class DDPackage>
+class DDEquivalenceChecker : public EquivalenceChecker {
+public:
+  DDEquivalenceChecker(const qc::QuantumComputation& qc1,
+                       const qc::QuantumComputation& qc2,
+                       Configuration                 configuration) noexcept;
 
-        EquivalenceCriterion run() override;
+  EquivalenceCriterion run() override;
 
-        void json(nlohmann::json& j) const noexcept override {
-            EquivalenceChecker::json(j);
-            j["max_nodes"] = maxActiveNodes;
-        }
+  void json(nlohmann::json& j) const noexcept override {
+    EquivalenceChecker::json(j);
+    j["max_nodes"] = maxActiveNodes;
+  }
 
-    protected:
-        std::unique_ptr<DDPackage> dd;
+protected:
+  std::unique_ptr<DDPackage> dd;
 
-        TaskManager<DDType, DDPackage> taskManager1;
-        TaskManager<DDType, DDPackage> taskManager2;
+  TaskManager<DDType, DDPackage> taskManager1;
+  TaskManager<DDType, DDPackage> taskManager2;
 
-        std::unique_ptr<ApplicationScheme<DDType, DDPackage>> applicationScheme;
+  std::unique_ptr<ApplicationScheme<DDType, DDPackage>> applicationScheme;
 
-        std::size_t maxActiveNodes{};
+  std::size_t maxActiveNodes{};
 
-        void initializeApplicationScheme(ApplicationSchemeType scheme);
+  void initializeApplicationScheme(ApplicationSchemeType scheme);
 
-        // at some point this routine should probably make its way into the DD package in some form
-        EquivalenceCriterion equals(const DDType& e, const DDType& f);
+  // at some point this routine should probably make its way into the DD package
+  // in some form
+  EquivalenceCriterion equals(const DDType& e, const DDType& f);
 
-        virtual void                 initializeTask(TaskManager<DDType, DDPackage>& taskManager) = 0;
-        virtual void                 initialize();
-        virtual void                 execute();
-        virtual void                 finish();
-        virtual void                 postprocessTask(TaskManager<DDType, DDPackage>& task);
-        virtual void                 postprocess();
-        virtual EquivalenceCriterion checkEquivalence();
-    };
+  virtual void initializeTask(TaskManager<DDType, DDPackage>& taskManager) = 0;
+  virtual void initialize();
+  virtual void execute();
+  virtual void finish();
+  virtual void postprocessTask(TaskManager<DDType, DDPackage>& task);
+  virtual void postprocess();
+  virtual EquivalenceCriterion checkEquivalence();
+};
 
 } // namespace ec

--- a/include/checker/dd/DDPackageConfigs.hpp
+++ b/include/checker/dd/DDPackageConfigs.hpp
@@ -1,6 +1,6 @@
 //
-// This file is part of MQT QCEC library which is released under the MIT license.
-// See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
 #pragma once
@@ -8,83 +8,108 @@
 #include "dd/Package.hpp"
 
 namespace ec {
-    struct SimulationDDPackageConfig: public dd::DDPackageConfig {
-        // simulation requires more resources for vectors.
-        static constexpr std::size_t UT_VEC_NBUCKET            = 65'536U;
-        static constexpr std::size_t CT_VEC_ADD_NBUCKET        = 65'536U;
-        static constexpr std::size_t CT_MAT_VEC_MULT_NBUCKET   = 65'536U;
-        static constexpr std::size_t CT_VEC_INNER_PROD_NBUCKET = 32'768U;
+struct SimulationDDPackageConfig : public dd::DDPackageConfig {
+  // simulation requires more resources for vectors.
+  static constexpr std::size_t UT_VEC_NBUCKET            = 65'536U;
+  static constexpr std::size_t CT_VEC_ADD_NBUCKET        = 65'536U;
+  static constexpr std::size_t CT_MAT_VEC_MULT_NBUCKET   = 65'536U;
+  static constexpr std::size_t CT_VEC_INNER_PROD_NBUCKET = 32'768U;
 
-        // simulation only needs matrices for representing operations. Hence, very little is needed here.
-        static constexpr std::size_t UT_MAT_NBUCKET                 = 128U;
-        static constexpr std::size_t UT_MAT_INITIAL_ALLOCATION_SIZE = 32U;
+  // simulation only needs matrices for representing operations. Hence, very
+  // little is needed here.
+  static constexpr std::size_t UT_MAT_NBUCKET                 = 128U;
+  static constexpr std::size_t UT_MAT_INITIAL_ALLOCATION_SIZE = 32U;
 
-        // simulation needs no matrix addition, conjugate transposition, matrix-matrix multiplication, or kronecker products.
-        static constexpr std::size_t CT_MAT_ADD_NBUCKET        = 1U;
-        static constexpr std::size_t CT_MAT_CONJ_TRANS_NBUCKET = 1U;
-        static constexpr std::size_t CT_MAT_MAT_MULT_NBUCKET   = 1U;
-        static constexpr std::size_t CT_VEC_KRON_NBUCKET       = 1U;
-        static constexpr std::size_t CT_MAT_KRON_NBUCKET       = 1U;
-    };
+  // simulation needs no matrix addition, conjugate transposition, matrix-matrix
+  // multiplication, or kronecker products.
+  static constexpr std::size_t CT_MAT_ADD_NBUCKET        = 1U;
+  static constexpr std::size_t CT_MAT_CONJ_TRANS_NBUCKET = 1U;
+  static constexpr std::size_t CT_MAT_MAT_MULT_NBUCKET   = 1U;
+  static constexpr std::size_t CT_VEC_KRON_NBUCKET       = 1U;
+  static constexpr std::size_t CT_MAT_KRON_NBUCKET       = 1U;
+};
 
-    using SimulationDDPackage = dd::Package<SimulationDDPackageConfig::UT_VEC_NBUCKET, SimulationDDPackageConfig::UT_VEC_INITIAL_ALLOCATION_SIZE,
-                                            SimulationDDPackageConfig::UT_MAT_NBUCKET, SimulationDDPackageConfig::UT_MAT_INITIAL_ALLOCATION_SIZE,
-                                            SimulationDDPackageConfig::CT_VEC_ADD_NBUCKET, SimulationDDPackageConfig::CT_MAT_ADD_NBUCKET,
-                                            SimulationDDPackageConfig::CT_MAT_TRANS_NBUCKET, SimulationDDPackageConfig::CT_MAT_CONJ_TRANS_NBUCKET,
-                                            SimulationDDPackageConfig::CT_MAT_VEC_MULT_NBUCKET, SimulationDDPackageConfig::CT_MAT_MAT_MULT_NBUCKET,
-                                            SimulationDDPackageConfig::CT_VEC_KRON_NBUCKET, SimulationDDPackageConfig::CT_MAT_KRON_NBUCKET,
-                                            SimulationDDPackageConfig::CT_VEC_INNER_PROD_NBUCKET>;
+using SimulationDDPackage =
+    dd::Package<SimulationDDPackageConfig::UT_VEC_NBUCKET,
+                SimulationDDPackageConfig::UT_VEC_INITIAL_ALLOCATION_SIZE,
+                SimulationDDPackageConfig::UT_MAT_NBUCKET,
+                SimulationDDPackageConfig::UT_MAT_INITIAL_ALLOCATION_SIZE,
+                SimulationDDPackageConfig::CT_VEC_ADD_NBUCKET,
+                SimulationDDPackageConfig::CT_MAT_ADD_NBUCKET,
+                SimulationDDPackageConfig::CT_MAT_TRANS_NBUCKET,
+                SimulationDDPackageConfig::CT_MAT_CONJ_TRANS_NBUCKET,
+                SimulationDDPackageConfig::CT_MAT_VEC_MULT_NBUCKET,
+                SimulationDDPackageConfig::CT_MAT_MAT_MULT_NBUCKET,
+                SimulationDDPackageConfig::CT_VEC_KRON_NBUCKET,
+                SimulationDDPackageConfig::CT_MAT_KRON_NBUCKET,
+                SimulationDDPackageConfig::CT_VEC_INNER_PROD_NBUCKET>;
 
-    struct ConstructionDDPackageConfig: public dd::DDPackageConfig {
-        // construction requires more resources for matrices.
-        static constexpr std::size_t UT_MAT_NBUCKET            = 65'536U;
-        static constexpr std::size_t CT_MAT_ADD_NBUCKET        = 65'536U;
-        static constexpr std::size_t CT_MAT_MAT_MULT_NBUCKET   = 65'536U;
-        static constexpr std::size_t CT_MAT_CONJ_TRANS_NBUCKET = 32'768U;
+struct ConstructionDDPackageConfig : public dd::DDPackageConfig {
+  // construction requires more resources for matrices.
+  static constexpr std::size_t UT_MAT_NBUCKET            = 65'536U;
+  static constexpr std::size_t CT_MAT_ADD_NBUCKET        = 65'536U;
+  static constexpr std::size_t CT_MAT_MAT_MULT_NBUCKET   = 65'536U;
+  static constexpr std::size_t CT_MAT_CONJ_TRANS_NBUCKET = 32'768U;
 
-        // construction does not need any vector nodes
-        static constexpr std::size_t UT_VEC_NBUCKET                 = 1U;
-        static constexpr std::size_t UT_VEC_INITIAL_ALLOCATION_SIZE = 1U;
+  // construction does not need any vector nodes
+  static constexpr std::size_t UT_VEC_NBUCKET                 = 1U;
+  static constexpr std::size_t UT_VEC_INITIAL_ALLOCATION_SIZE = 1U;
 
-        // construction needs no vector addition, matrix-vector multiplication, kronecker products, or inner products.
-        static constexpr std::size_t CT_VEC_ADD_NBUCKET        = 1U;
-        static constexpr std::size_t CT_MAT_VEC_MULT_NBUCKET   = 1U;
-        static constexpr std::size_t CT_VEC_KRON_NBUCKET       = 1U;
-        static constexpr std::size_t CT_MAT_KRON_NBUCKET       = 1U;
-        static constexpr std::size_t CT_VEC_INNER_PROD_NBUCKET = 1U;
-    };
+  // construction needs no vector addition, matrix-vector multiplication,
+  // kronecker products, or inner products.
+  static constexpr std::size_t CT_VEC_ADD_NBUCKET        = 1U;
+  static constexpr std::size_t CT_MAT_VEC_MULT_NBUCKET   = 1U;
+  static constexpr std::size_t CT_VEC_KRON_NBUCKET       = 1U;
+  static constexpr std::size_t CT_MAT_KRON_NBUCKET       = 1U;
+  static constexpr std::size_t CT_VEC_INNER_PROD_NBUCKET = 1U;
+};
 
-    using ConstructionDDPackage = dd::Package<ConstructionDDPackageConfig::UT_VEC_NBUCKET, ConstructionDDPackageConfig::UT_VEC_INITIAL_ALLOCATION_SIZE,
-                                              ConstructionDDPackageConfig::UT_MAT_NBUCKET, ConstructionDDPackageConfig::UT_MAT_INITIAL_ALLOCATION_SIZE,
-                                              ConstructionDDPackageConfig::CT_VEC_ADD_NBUCKET, ConstructionDDPackageConfig::CT_MAT_ADD_NBUCKET,
-                                              ConstructionDDPackageConfig::CT_MAT_TRANS_NBUCKET, ConstructionDDPackageConfig::CT_MAT_CONJ_TRANS_NBUCKET,
-                                              ConstructionDDPackageConfig::CT_MAT_VEC_MULT_NBUCKET, ConstructionDDPackageConfig::CT_MAT_MAT_MULT_NBUCKET,
-                                              ConstructionDDPackageConfig::CT_VEC_KRON_NBUCKET, ConstructionDDPackageConfig::CT_MAT_KRON_NBUCKET,
-                                              ConstructionDDPackageConfig::CT_VEC_INNER_PROD_NBUCKET>;
+using ConstructionDDPackage =
+    dd::Package<ConstructionDDPackageConfig::UT_VEC_NBUCKET,
+                ConstructionDDPackageConfig::UT_VEC_INITIAL_ALLOCATION_SIZE,
+                ConstructionDDPackageConfig::UT_MAT_NBUCKET,
+                ConstructionDDPackageConfig::UT_MAT_INITIAL_ALLOCATION_SIZE,
+                ConstructionDDPackageConfig::CT_VEC_ADD_NBUCKET,
+                ConstructionDDPackageConfig::CT_MAT_ADD_NBUCKET,
+                ConstructionDDPackageConfig::CT_MAT_TRANS_NBUCKET,
+                ConstructionDDPackageConfig::CT_MAT_CONJ_TRANS_NBUCKET,
+                ConstructionDDPackageConfig::CT_MAT_VEC_MULT_NBUCKET,
+                ConstructionDDPackageConfig::CT_MAT_MAT_MULT_NBUCKET,
+                ConstructionDDPackageConfig::CT_VEC_KRON_NBUCKET,
+                ConstructionDDPackageConfig::CT_MAT_KRON_NBUCKET,
+                ConstructionDDPackageConfig::CT_VEC_INNER_PROD_NBUCKET>;
 
-    struct AlternatingDDPackageConfig: public dd::DDPackageConfig {
-        // The alternating checker requires more resources for matrices.
-        static constexpr std::size_t UT_MAT_NBUCKET          = 65'536U;
-        static constexpr std::size_t CT_MAT_ADD_NBUCKET      = 65'536U;
-        static constexpr std::size_t CT_MAT_MAT_MULT_NBUCKET = 65'536U;
+struct AlternatingDDPackageConfig : public dd::DDPackageConfig {
+  // The alternating checker requires more resources for matrices.
+  static constexpr std::size_t UT_MAT_NBUCKET          = 65'536U;
+  static constexpr std::size_t CT_MAT_ADD_NBUCKET      = 65'536U;
+  static constexpr std::size_t CT_MAT_MAT_MULT_NBUCKET = 65'536U;
 
-        // The alternating checker does not need any vector nodes
-        static constexpr std::size_t UT_VEC_NBUCKET                 = 1U;
-        static constexpr std::size_t UT_VEC_INITIAL_ALLOCATION_SIZE = 1U;
+  // The alternating checker does not need any vector nodes
+  static constexpr std::size_t UT_VEC_NBUCKET                 = 1U;
+  static constexpr std::size_t UT_VEC_INITIAL_ALLOCATION_SIZE = 1U;
 
-        // The alternating needs no vector addition, matrix-vector multiplication, kronecker products, or inner products.
-        static constexpr std::size_t CT_VEC_ADD_NBUCKET        = 1U;
-        static constexpr std::size_t CT_MAT_VEC_MULT_NBUCKET   = 1U;
-        static constexpr std::size_t CT_VEC_KRON_NBUCKET       = 1U;
-        static constexpr std::size_t CT_MAT_KRON_NBUCKET       = 1U;
-        static constexpr std::size_t CT_VEC_INNER_PROD_NBUCKET = 1U;
-    };
+  // The alternating needs no vector addition, matrix-vector multiplication,
+  // kronecker products, or inner products.
+  static constexpr std::size_t CT_VEC_ADD_NBUCKET        = 1U;
+  static constexpr std::size_t CT_MAT_VEC_MULT_NBUCKET   = 1U;
+  static constexpr std::size_t CT_VEC_KRON_NBUCKET       = 1U;
+  static constexpr std::size_t CT_MAT_KRON_NBUCKET       = 1U;
+  static constexpr std::size_t CT_VEC_INNER_PROD_NBUCKET = 1U;
+};
 
-    using AlternatingDDPackage = dd::Package<AlternatingDDPackageConfig::UT_VEC_NBUCKET, AlternatingDDPackageConfig::UT_VEC_INITIAL_ALLOCATION_SIZE,
-                                             AlternatingDDPackageConfig::UT_MAT_NBUCKET, AlternatingDDPackageConfig::UT_MAT_INITIAL_ALLOCATION_SIZE,
-                                             AlternatingDDPackageConfig::CT_VEC_ADD_NBUCKET, AlternatingDDPackageConfig::CT_MAT_ADD_NBUCKET,
-                                             AlternatingDDPackageConfig::CT_MAT_TRANS_NBUCKET, AlternatingDDPackageConfig::CT_MAT_CONJ_TRANS_NBUCKET,
-                                             AlternatingDDPackageConfig::CT_MAT_VEC_MULT_NBUCKET, AlternatingDDPackageConfig::CT_MAT_MAT_MULT_NBUCKET,
-                                             AlternatingDDPackageConfig::CT_VEC_KRON_NBUCKET, AlternatingDDPackageConfig::CT_MAT_KRON_NBUCKET,
-                                             AlternatingDDPackageConfig::CT_VEC_INNER_PROD_NBUCKET>;
+using AlternatingDDPackage =
+    dd::Package<AlternatingDDPackageConfig::UT_VEC_NBUCKET,
+                AlternatingDDPackageConfig::UT_VEC_INITIAL_ALLOCATION_SIZE,
+                AlternatingDDPackageConfig::UT_MAT_NBUCKET,
+                AlternatingDDPackageConfig::UT_MAT_INITIAL_ALLOCATION_SIZE,
+                AlternatingDDPackageConfig::CT_VEC_ADD_NBUCKET,
+                AlternatingDDPackageConfig::CT_MAT_ADD_NBUCKET,
+                AlternatingDDPackageConfig::CT_MAT_TRANS_NBUCKET,
+                AlternatingDDPackageConfig::CT_MAT_CONJ_TRANS_NBUCKET,
+                AlternatingDDPackageConfig::CT_MAT_VEC_MULT_NBUCKET,
+                AlternatingDDPackageConfig::CT_MAT_MAT_MULT_NBUCKET,
+                AlternatingDDPackageConfig::CT_VEC_KRON_NBUCKET,
+                AlternatingDDPackageConfig::CT_MAT_KRON_NBUCKET,
+                AlternatingDDPackageConfig::CT_VEC_INNER_PROD_NBUCKET>;
 } // namespace ec

--- a/include/checker/dd/DDSimulationChecker.hpp
+++ b/include/checker/dd/DDSimulationChecker.hpp
@@ -1,6 +1,6 @@
 //
-// This file is part of MQT QCEC library which is released under the MIT license.
-// See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
 #pragma once
@@ -9,26 +9,37 @@
 #include "DDPackageConfigs.hpp"
 
 namespace ec {
-    class DDSimulationChecker final: public DDEquivalenceChecker<qc::VectorDD, SimulationDDPackage> {
-    public:
-        DDSimulationChecker(const qc::QuantumComputation& qc1, const qc::QuantumComputation& qc2, Configuration configuration) noexcept;
+class DDSimulationChecker final
+    : public DDEquivalenceChecker<qc::VectorDD, SimulationDDPackage> {
+public:
+  DDSimulationChecker(const qc::QuantumComputation& qc1,
+                      const qc::QuantumComputation& qc2,
+                      Configuration                 configuration) noexcept;
 
-        void setRandomInitialState(StateGenerator& generator);
+  void setRandomInitialState(StateGenerator& generator);
 
-        [[nodiscard]] dd::CVec getInitialVector() const { return dd->getVector(initialState); }
-        [[nodiscard]] dd::CVec getInternalVector1() const { return dd->getVector(taskManager1.getInternalState()); }
-        [[nodiscard]] dd::CVec getInternalVector2() const { return dd->getVector(taskManager2.getInternalState()); }
+  [[nodiscard]] dd::CVec getInitialVector() const {
+    return dd->getVector(initialState);
+  }
+  [[nodiscard]] dd::CVec getInternalVector1() const {
+    return dd->getVector(taskManager1.getInternalState());
+  }
+  [[nodiscard]] dd::CVec getInternalVector2() const {
+    return dd->getVector(taskManager2.getInternalState());
+  }
 
-        void json(nlohmann::json& j) const noexcept override {
-            DDEquivalenceChecker::json(j);
-            j["checker"] = "decision_diagram_simulation";
-        }
+  void json(nlohmann::json& j) const noexcept override {
+    DDEquivalenceChecker::json(j);
+    j["checker"] = "decision_diagram_simulation";
+  }
 
-    private:
-        // the initial state used for simulation. defaults to the all-zero state |0...0>
-        qc::VectorDD initialState{};
+private:
+  // the initial state used for simulation. defaults to the all-zero state
+  // |0...0>
+  qc::VectorDD initialState{};
 
-        void                 initializeTask(TaskManager<qc::VectorDD, SimulationDDPackage>& taskManager) override;
-        EquivalenceCriterion checkEquivalence() override;
-    };
+  void initializeTask(
+      TaskManager<qc::VectorDD, SimulationDDPackage>& taskManager) override;
+  EquivalenceCriterion checkEquivalence() override;
+};
 } // namespace ec

--- a/include/checker/dd/TaskManager.hpp
+++ b/include/checker/dd/TaskManager.hpp
@@ -1,6 +1,6 @@
 //
-// This file is part of MQT QCEC library which is released under the MIT license.
-// See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
 #pragma once
@@ -9,124 +9,131 @@
 #include "dd/Operations.hpp"
 
 namespace ec {
-    enum class Direction : bool { Left  = true,
-                                  Right = false };
+enum class Direction : bool { Left = true, Right = false };
 
-    template<class DDType, class DDPackage = dd::Package<>>
-    class TaskManager {
-    public:
-        TaskManager(const qc::QuantumComputation& qc, std::unique_ptr<DDPackage>& package, const ec::Direction& direction) noexcept:
-            qc(&qc), package(package), direction(direction), permutation(qc.initialLayout), iterator(qc.begin()), end(qc.end()) {}
-        TaskManager(const qc::QuantumComputation& qc, std::unique_ptr<DDPackage>& package) noexcept:
-            TaskManager(qc, package, Direction::Left) {}
+template <class DDType, class DDPackage = dd::Package<>> class TaskManager {
+public:
+  TaskManager(const qc::QuantumComputation& qc,
+              std::unique_ptr<DDPackage>&   package,
+              const ec::Direction&          direction) noexcept
+      : qc(&qc), package(package), direction(direction),
+        permutation(qc.initialLayout), iterator(qc.begin()), end(qc.end()) {}
+  TaskManager(const qc::QuantumComputation& qc,
+              std::unique_ptr<DDPackage>&   package) noexcept
+      : TaskManager(qc, package, Direction::Left) {}
 
-        [[nodiscard]] bool finished() const noexcept { return iterator == end; }
+  [[nodiscard]] bool finished() const noexcept { return iterator == end; }
 
-        const std::unique_ptr<qc::Operation>& operator()() const { return *iterator; }
+  const std::unique_ptr<qc::Operation>& operator()() const { return *iterator; }
 
-        [[nodiscard]] const DDType& getInternalState() const noexcept {
-            return internalState;
-        }
-        void setInternalState(const DDType& state) noexcept {
-            internalState = state;
-        }
-        void flipDirection() noexcept {
-            if (direction == Direction::Left) {
-                direction = Direction::Right;
-            } else {
-                direction = Direction::Left;
-            }
-        }
+  [[nodiscard]] const DDType& getInternalState() const noexcept {
+    return internalState;
+  }
+  void setInternalState(const DDType& state) noexcept { internalState = state; }
+  void flipDirection() noexcept {
+    if (direction == Direction::Left) {
+      direction = Direction::Right;
+    } else {
+      direction = Direction::Left;
+    }
+  }
 
-        [[nodiscard]] qc::MatrixDD getDD() { return dd::getDD((*iterator).get(), package, permutation); }
-        [[nodiscard]] qc::MatrixDD getInverseDD() { return dd::getInverseDD((*iterator).get(), package, permutation); }
+  [[nodiscard]] qc::MatrixDD getDD() {
+    return dd::getDD((*iterator).get(), package, permutation);
+  }
+  [[nodiscard]] qc::MatrixDD getInverseDD() {
+    return dd::getInverseDD((*iterator).get(), package, permutation);
+  }
 
-        [[nodiscard]] const qc::QuantumComputation* getCircuit() const noexcept { return qc; }
+  [[nodiscard]] const qc::QuantumComputation* getCircuit() const noexcept {
+    return qc;
+  }
 
-        [[nodiscard]] const qc::Permutation& getPermutation() const noexcept { return permutation; }
+  [[nodiscard]] const qc::Permutation& getPermutation() const noexcept {
+    return permutation;
+  }
 
-        void advanceIterator() { ++iterator; }
+  void advanceIterator() { ++iterator; }
 
-        void applyGate(DDType& to) {
-            auto saved = to;
-            if constexpr (std::is_same_v<DDType, qc::VectorDD>) {
-                // direction has no effect on state vector DDs
-                to = package->multiply(getDD(), to);
-            } else {
-                if (direction == Direction::Left) {
-                    to = package->multiply(getDD(), to);
-                } else {
-                    to = package->multiply(to, getInverseDD());
-                }
-            }
-            package->incRef(to);
-            package->decRef(saved);
-            package->garbageCollect();
-            ++iterator;
-        }
+  void applyGate(DDType& to) {
+    auto saved = to;
+    if constexpr (std::is_same_v<DDType, qc::VectorDD>) {
+      // direction has no effect on state vector DDs
+      to = package->multiply(getDD(), to);
+    } else {
+      if (direction == Direction::Left) {
+        to = package->multiply(getDD(), to);
+      } else {
+        to = package->multiply(to, getInverseDD());
+      }
+    }
+    package->incRef(to);
+    package->decRef(saved);
+    package->garbageCollect();
+    ++iterator;
+  }
 
-        void applySwapOperations(DDType& state) {
-            while (!finished() && (*iterator)->getType() == qc::SWAP) {
-                applyGate(state);
-            }
-        }
-        void applySwapOperations() { applySwapOperations(internalState); }
+  void applySwapOperations(DDType& state) {
+    while (!finished() && (*iterator)->getType() == qc::SWAP) {
+      applyGate(state);
+    }
+  }
+  void applySwapOperations() { applySwapOperations(internalState); }
 
-        void advance(DDType& state, const std::size_t steps) {
-            for (std::size_t i = 0U; i < steps && !finished(); ++i) {
-                applyGate(state);
-                applySwapOperations(state);
-            }
-        }
-        void advance(DDType& state) { advance(state, 1U); }
-        void advance(std::size_t steps) { advance(internalState, steps); }
-        void advance() { advance(1U); }
+  void advance(DDType& state, const std::size_t steps) {
+    for (std::size_t i = 0U; i < steps && !finished(); ++i) {
+      applyGate(state);
+      applySwapOperations(state);
+    }
+  }
+  void advance(DDType& state) { advance(state, 1U); }
+  void advance(std::size_t steps) { advance(internalState, steps); }
+  void advance() { advance(1U); }
 
-        void finish(DDType& state) {
-            while (!finished()) {
-                advance(state);
-            }
-        }
-        void finish() { finish(internalState); }
+  void finish(DDType& state) {
+    while (!finished()) {
+      advance(state);
+    }
+  }
+  void finish() { finish(internalState); }
 
-        void changePermutation(DDType& state) {
-            dd::changePermutation(state, permutation, qc->outputPermutation, package, static_cast<bool>(direction));
-        }
-        void changePermutation() { changePermutation(internalState); }
+  void changePermutation(DDType& state) {
+    dd::changePermutation(state, permutation, qc->outputPermutation, package,
+                          static_cast<bool>(direction));
+  }
+  void changePermutation() { changePermutation(internalState); }
 
-        void reduceAncillae(DDType& state) {
-            if constexpr (std::is_same_v<DDType, qc::MatrixDD>) {
-                state = package->reduceAncillae(state, qc->ancillary, static_cast<bool>(direction));
-            }
-        }
-        void reduceAncillae() { reduceAncillae(internalState); }
+  void reduceAncillae(DDType& state) {
+    if constexpr (std::is_same_v<DDType, qc::MatrixDD>) {
+      state = package->reduceAncillae(state, qc->ancillary,
+                                      static_cast<bool>(direction));
+    }
+  }
+  void reduceAncillae() { reduceAncillae(internalState); }
 
-        void reduceGarbage(DDType& state) {
-            if constexpr (std::is_same_v<DDType, qc::VectorDD>) {
-                state = package->reduceGarbage(state, qc->garbage);
-            } else if constexpr (std::is_same_v<DDType, qc::MatrixDD>) {
-                state = package->reduceGarbage(state, qc->garbage, static_cast<bool>(direction));
-            }
-        }
-        void reduceGarbage() { reduceGarbage(internalState); }
+  void reduceGarbage(DDType& state) {
+    if constexpr (std::is_same_v<DDType, qc::VectorDD>) {
+      state = package->reduceGarbage(state, qc->garbage);
+    } else if constexpr (std::is_same_v<DDType, qc::MatrixDD>) {
+      state = package->reduceGarbage(state, qc->garbage,
+                                     static_cast<bool>(direction));
+    }
+  }
+  void reduceGarbage() { reduceGarbage(internalState); }
 
-        void incRef(DDType& state) {
-            package->incRef(state);
-        }
-        void incRef() { incRef(internalState); }
+  void incRef(DDType& state) { package->incRef(state); }
+  void incRef() { incRef(internalState); }
 
-        void decRef(DDType& state) {
-            package->decRef(state);
-        }
-        void decRef() { decRef(internalState); }
+  void decRef(DDType& state) { package->decRef(state); }
+  void decRef() { decRef(internalState); }
 
-    private:
-        const qc::QuantumComputation* qc{};
-        std::unique_ptr<DDPackage>&   package;
-        ec::Direction                 direction = Direction::Left;
-        qc::Permutation               permutation{};
-        decltype(qc->begin())         iterator;
-        decltype(qc->end())           end;
-        DDType                        internalState{};
-    };
+private:
+  const qc::QuantumComputation* qc{};
+  std::unique_ptr<DDPackage>&   package;
+  ec::Direction                 direction = Direction::Left;
+  qc::Permutation               permutation{};
+  decltype(qc->begin())         iterator;
+  decltype(qc->end())           end;
+  DDType                        internalState{};
+};
 } // namespace ec

--- a/include/checker/dd/applicationscheme/ApplicationScheme.hpp
+++ b/include/checker/dd/applicationscheme/ApplicationScheme.hpp
@@ -1,6 +1,6 @@
 //
-// This file is part of MQT QCEC library which is released under the MIT license.
-// See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
 #pragma once
@@ -12,85 +12,95 @@
 #include <stdexcept>
 
 namespace ec {
-    // A list of application schemes that implement the below interface
-    enum class ApplicationSchemeType {
-        Sequential   = 0,
-        OneToOne     = 1,
-        Lookahead    = 2,
-        GateCost     = 3,
-        Proportional = 4
-    };
+// A list of application schemes that implement the below interface
+enum class ApplicationSchemeType {
+  Sequential   = 0,
+  OneToOne     = 1,
+  Lookahead    = 2,
+  GateCost     = 3,
+  Proportional = 4
+};
 
-    inline std::string toString(const ApplicationSchemeType& applicationScheme) noexcept {
-        switch (applicationScheme) {
-            case ApplicationSchemeType::Sequential:
-                return "sequential";
-            case ApplicationSchemeType::OneToOne:
-                return "one_to_one";
-            case ApplicationSchemeType::Lookahead:
-                return "lookahead";
-            case ApplicationSchemeType::GateCost:
-                return "gate_cost";
-            default:
-                return "proportional";
-        }
-    }
+inline std::string
+toString(const ApplicationSchemeType& applicationScheme) noexcept {
+  switch (applicationScheme) {
+  case ApplicationSchemeType::Sequential:
+    return "sequential";
+  case ApplicationSchemeType::OneToOne:
+    return "one_to_one";
+  case ApplicationSchemeType::Lookahead:
+    return "lookahead";
+  case ApplicationSchemeType::GateCost:
+    return "gate_cost";
+  default:
+    return "proportional";
+  }
+}
 
-    inline ApplicationSchemeType applicationSchemeFromString(const std::string& applicationScheme) noexcept {
-        if ((applicationScheme == "sequential") || (applicationScheme == "0") || (applicationScheme == "reference")) {
-            return ApplicationSchemeType::Sequential;
-        }
-        if ((applicationScheme == "one_to_one") || (applicationScheme == "1") || (applicationScheme == "naive")) {
-            return ApplicationSchemeType::OneToOne;
-        }
-        if ((applicationScheme == "lookahead") || (applicationScheme == "2")) {
-            return ApplicationSchemeType::Lookahead;
-        }
-        if ((applicationScheme == "gate_cost") || (applicationScheme == "3") || (applicationScheme == "compilation_flow")) {
-            return ApplicationSchemeType::GateCost;
-        }
-        if ((applicationScheme == "proportional") || (applicationScheme == "4")) {
-            return ApplicationSchemeType::Proportional;
-        }
-        std::cerr << "Unknown application scheme: " << applicationScheme << ". Defaulting to proportional!\n";
-        return ApplicationSchemeType::Proportional;
-    }
+inline ApplicationSchemeType
+applicationSchemeFromString(const std::string& applicationScheme) noexcept {
+  if ((applicationScheme == "sequential") || (applicationScheme == "0") ||
+      (applicationScheme == "reference")) {
+    return ApplicationSchemeType::Sequential;
+  }
+  if ((applicationScheme == "one_to_one") || (applicationScheme == "1") ||
+      (applicationScheme == "naive")) {
+    return ApplicationSchemeType::OneToOne;
+  }
+  if ((applicationScheme == "lookahead") || (applicationScheme == "2")) {
+    return ApplicationSchemeType::Lookahead;
+  }
+  if ((applicationScheme == "gate_cost") || (applicationScheme == "3") ||
+      (applicationScheme == "compilation_flow")) {
+    return ApplicationSchemeType::GateCost;
+  }
+  if ((applicationScheme == "proportional") || (applicationScheme == "4")) {
+    return ApplicationSchemeType::Proportional;
+  }
+  std::cerr << "Unknown application scheme: " << applicationScheme
+            << ". Defaulting to proportional!\n";
+  return ApplicationSchemeType::Proportional;
+}
 
-    inline std::istream& operator>>(std::istream& in, ApplicationSchemeType& applicationScheme) {
-        std::string token;
-        in >> token;
+inline std::istream& operator>>(std::istream&          in,
+                                ApplicationSchemeType& applicationScheme) {
+  std::string token;
+  in >> token;
 
-        if (token.empty()) {
-            in.setstate(std::istream::failbit);
-            return in;
-        }
+  if (token.empty()) {
+    in.setstate(std::istream::failbit);
+    return in;
+  }
 
-        applicationScheme = applicationSchemeFromString(token);
-        return in;
-    }
+  applicationScheme = applicationSchemeFromString(token);
+  return in;
+}
 
-    inline std::ostream& operator<<(std::ostream& out, const ApplicationSchemeType& applicationScheme) {
-        out << toString(applicationScheme);
-        return out;
-    }
+inline std::ostream&
+operator<<(std::ostream& out, const ApplicationSchemeType& applicationScheme) {
+  out << toString(applicationScheme);
+  return out;
+}
 
-    // Interface for describing an application scheme
-    // Given the current state of the check (tracked by two task managers), an application scheme describes how to
-    // proceed with the check, i.e., how many operations to apply from either circuit.
-    template<class DDType, class DDPackage = dd::Package<>>
-    class ApplicationScheme {
-    public:
-        ApplicationScheme(TaskManager<DDType, DDPackage>& taskManager1, TaskManager<DDType, DDPackage>& taskManager2) noexcept:
-            taskManager1(taskManager1), taskManager2(taskManager2){};
+// Interface for describing an application scheme
+// Given the current state of the check (tracked by two task managers), an
+// application scheme describes how to proceed with the check, i.e., how many
+// operations to apply from either circuit.
+template <class DDType, class DDPackage = dd::Package<>>
+class ApplicationScheme {
+public:
+  ApplicationScheme(TaskManager<DDType, DDPackage>& taskManager1,
+                    TaskManager<DDType, DDPackage>& taskManager2) noexcept
+      : taskManager1(taskManager1), taskManager2(taskManager2){};
 
-        virtual ~ApplicationScheme() = default;
+  virtual ~ApplicationScheme() = default;
 
-        // get how many gates from either circuit shall be applied next
-        virtual std::pair<std::size_t, std::size_t> operator()() = 0;
+  // get how many gates from either circuit shall be applied next
+  virtual std::pair<std::size_t, std::size_t> operator()() = 0;
 
-    protected:
-        TaskManager<DDType, DDPackage>& taskManager1;
-        TaskManager<DDType, DDPackage>& taskManager2;
-    };
+protected:
+  TaskManager<DDType, DDPackage>& taskManager1;
+  TaskManager<DDType, DDPackage>& taskManager2;
+};
 
 } // namespace ec

--- a/include/checker/dd/applicationscheme/GateCostApplicationScheme.hpp
+++ b/include/checker/dd/applicationscheme/GateCostApplicationScheme.hpp
@@ -1,6 +1,6 @@
 //
-// This file is part of MQT QCEC library which is released under the MIT license.
-// See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
 #pragma once
@@ -15,163 +15,181 @@
 #include <utility>
 
 namespace std {
-    template<>
-    struct hash<std::pair<qc::OpType, dd::QubitCount>> {
-        std::size_t operator()(pair<qc::OpType, dd::QubitCount> const& key) const noexcept {
-            const std::size_t h1 = hash<decltype(key.first)>{}(key.first);
-            const std::size_t h2 = hash<decltype(key.second)>{}(key.second);
-            return h1 ^ (h2 << 1);
-        }
-    };
+template <> struct hash<std::pair<qc::OpType, dd::QubitCount>> {
+  std::size_t
+  operator()(pair<qc::OpType, dd::QubitCount> const& key) const noexcept {
+    const std::size_t h1 = hash<decltype(key.first)>{}(key.first);
+    const std::size_t h2 = hash<decltype(key.second)>{}(key.second);
+    return h1 ^ (h2 << 1);
+  }
+};
 } // namespace std
 
 namespace ec {
-    using GateCostLUTKeyType = std::pair<qc::OpType, dd::QubitCount>;
-    using GateCostLUT        = std::unordered_map<GateCostLUTKeyType, std::size_t>;
-    using CostFunction       = std::function<std::size_t(const GateCostLUTKeyType&)>;
+using GateCostLUTKeyType = std::pair<qc::OpType, dd::QubitCount>;
+using GateCostLUT        = std::unordered_map<GateCostLUTKeyType, std::size_t>;
+using CostFunction = std::function<std::size_t(const GateCostLUTKeyType&)>;
 
-    template<class DDType, class DDPackage = dd::Package<>>
-    class GateCostApplicationScheme final: public ApplicationScheme<DDType, DDPackage> {
-    public:
-        GateCostApplicationScheme(TaskManager<DDType, DDPackage>& taskManager1, TaskManager<DDType, DDPackage>& taskManager2, const CostFunction& costFunction):
-            ApplicationScheme<DDType, DDPackage>(taskManager1, taskManager2) {
-            populateLUT(costFunction, taskManager1.getCircuit());
-            populateLUT(costFunction, taskManager2.getCircuit());
-        }
+template <class DDType, class DDPackage = dd::Package<>>
+class GateCostApplicationScheme final
+    : public ApplicationScheme<DDType, DDPackage> {
+public:
+  GateCostApplicationScheme(TaskManager<DDType, DDPackage>& taskManager1,
+                            TaskManager<DDType, DDPackage>& taskManager2,
+                            const CostFunction&             costFunction)
+      : ApplicationScheme<DDType, DDPackage>(taskManager1, taskManager2) {
+    populateLUT(costFunction, taskManager1.getCircuit());
+    populateLUT(costFunction, taskManager2.getCircuit());
+  }
 
-        GateCostApplicationScheme(TaskManager<DDType, DDPackage>& taskManager1, TaskManager<DDType, DDPackage>& taskManager2, const std::string& filename):
-            ApplicationScheme<DDType, DDPackage>(taskManager1, taskManager2) {
-            populateLUT(filename);
-        }
+  GateCostApplicationScheme(TaskManager<DDType, DDPackage>& taskManager1,
+                            TaskManager<DDType, DDPackage>& taskManager2,
+                            const std::string&              filename)
+      : ApplicationScheme<DDType, DDPackage>(taskManager1, taskManager2) {
+    populateLUT(filename);
+  }
 
-        std::pair<size_t, size_t> operator()() override {
-            if (gateCostLUT.empty()) {
-                return {1U, 1U};
-            }
-
-            const auto& op   = this->taskManager1();
-            const auto  key  = GateCostLUTKeyType{op->getType(), op->getNcontrols()};
-            std::size_t cost = 1U;
-            if (auto it = gateCostLUT.find(key); it != gateCostLUT.end()) {
-                cost = it->second;
-            }
-            return {1U, cost};
-        }
-
-    private:
-        GateCostLUT gateCostLUT{};
-
-        template<class CostFun>
-        void populateLUT(CostFun costFunction, const qc::QuantumComputation* qc) {
-            for (const auto& op: *qc) {
-                const auto type      = op->getType();
-                const auto nControls = op->getNcontrols();
-                const auto key       = GateCostLUTKeyType{type, nControls};
-                if (const auto it = gateCostLUT.find(key); it == gateCostLUT.end()) {
-                    const auto cost = costFunction(key);
-                    gateCostLUT.emplace(key, cost);
-                }
-            }
-        }
-
-        // read gate cost LUT from file
-        // very simple file format:
-        // each line consists of
-        // <identifier> <controls> <cost>
-        void populateLUT(const std::string& filename) {
-            std::ifstream ifs(filename);
-            if (!ifs.good()) {
-                throw std::invalid_argument("Error opening LUT file: " + filename);
-            }
-            populateLUT(ifs);
-        }
-        void populateLUT(std::istream& is) {
-            qc::OpType  opType    = qc::OpType::None;
-            std::size_t nControls = 0U;
-            std::size_t cost      = 1U;
-            while (is.good() && (is >> opType >> nControls >> cost)) {
-                gateCostLUT.emplace(std::pair{opType, nControls}, cost);
-            }
-        }
-    };
-
-    [[nodiscard]] static std::size_t LegacyIBMCostFunction(const GateCostLUTKeyType& key) noexcept {
-        const auto [gate, nc] = key;
-
-        if (nc == 0U) {
-            switch (gate) {
-                case qc::I:
-                case qc::H:
-                case qc::X:
-                case qc::Y:
-                case qc::Z:
-                case qc::S:
-                case qc::Sdag:
-                case qc::T:
-                case qc::Tdag:
-                case qc::Phase:
-                case qc::U2:
-                case qc::U3:
-                case qc::SX:
-                case qc::SXdag:
-                case qc::V:
-                case qc::Vdag:
-                case qc::RX:
-                case qc::RY:
-                case qc::RZ:
-                // the following are merely placeholders so that the check can advance
-                case qc::Compound:
-                case qc::Measure:
-                case qc::Reset:
-                case qc::Snapshot:
-                case qc::ShowProbabilities:
-                case qc::Barrier:
-                case qc::ClassicControlled:
-                    return 1U;
-                default:
-                    break;
-            }
-        }
-
-        // special treatment for CNOT
-        if ((gate == qc::X) && (nc == 1U)) {
-            return 1U;
-        }
-
-        switch (gate) {
-            case qc::X:
-                return 2UL * (nc - 2UL) * ((2UL * LegacyIBMCostFunction({qc::Phase, 0})) + (2UL * LegacyIBMCostFunction({qc::U2, 0})) + (3UL * LegacyIBMCostFunction({qc::X, 1}))) + (6UL * LegacyIBMCostFunction({qc::X, 1})) + (8UL * LegacyIBMCostFunction({qc::U3, 0}));
-            case qc::U3:
-            case qc::U2:
-            case qc::V:
-            case qc::Vdag:
-            case qc::RX:
-            case qc::RY:
-            case qc::H:
-            case qc::SX:
-            case qc::SXdag:
-                // heuristic
-                return (2U * LegacyIBMCostFunction({qc::X, nc})) + (4U * LegacyIBMCostFunction({qc::U3, 0}));
-            case qc::Phase:
-            case qc::S:
-            case qc::Sdag:
-            case qc::T:
-            case qc::Tdag:
-            case qc::RZ:
-                // heuristic
-                return (2U * LegacyIBMCostFunction({qc::X, nc})) + (3U * LegacyIBMCostFunction({qc::Phase, 0}));
-            case qc::Y:
-            case qc::Z:
-                return LegacyIBMCostFunction({qc::X, nc}) + (2U * LegacyIBMCostFunction({qc::U3, 0}));
-            case qc::SWAP:
-                return LegacyIBMCostFunction({qc::X, nc}) + (2U * LegacyIBMCostFunction({qc::X, 1}));
-            case qc::iSWAP:
-                return (2U * LegacyIBMCostFunction({qc::X, nc + 1U})) + (2U * LegacyIBMCostFunction({qc::S, nc})) + (2U * LegacyIBMCostFunction({qc::H, nc}));
-            case qc::Peres:
-            case qc::Peresdag:
-                return LegacyIBMCostFunction({qc::X, nc + 1U}) + LegacyIBMCostFunction({qc::X, nc});
-            default:
-                return 1U;
-        }
+  std::pair<size_t, size_t> operator()() override {
+    if (gateCostLUT.empty()) {
+      return {1U, 1U};
     }
+
+    const auto& op   = this->taskManager1();
+    const auto  key  = GateCostLUTKeyType{op->getType(), op->getNcontrols()};
+    std::size_t cost = 1U;
+    if (auto it = gateCostLUT.find(key); it != gateCostLUT.end()) {
+      cost = it->second;
+    }
+    return {1U, cost};
+  }
+
+private:
+  GateCostLUT gateCostLUT{};
+
+  template <class CostFun>
+  void populateLUT(CostFun costFunction, const qc::QuantumComputation* qc) {
+    for (const auto& op : *qc) {
+      const auto type      = op->getType();
+      const auto nControls = op->getNcontrols();
+      const auto key       = GateCostLUTKeyType{type, nControls};
+      if (const auto it = gateCostLUT.find(key); it == gateCostLUT.end()) {
+        const auto cost = costFunction(key);
+        gateCostLUT.emplace(key, cost);
+      }
+    }
+  }
+
+  // read gate cost LUT from file
+  // very simple file format:
+  // each line consists of
+  // <identifier> <controls> <cost>
+  void populateLUT(const std::string& filename) {
+    std::ifstream ifs(filename);
+    if (!ifs.good()) {
+      throw std::invalid_argument("Error opening LUT file: " + filename);
+    }
+    populateLUT(ifs);
+  }
+  void populateLUT(std::istream& is) {
+    qc::OpType  opType    = qc::OpType::None;
+    std::size_t nControls = 0U;
+    std::size_t cost      = 1U;
+    while (is.good() && (is >> opType >> nControls >> cost)) {
+      gateCostLUT.emplace(std::pair{opType, nControls}, cost);
+    }
+  }
+};
+
+[[nodiscard]] static std::size_t
+LegacyIBMCostFunction(const GateCostLUTKeyType& key) noexcept {
+  const auto [gate, nc] = key;
+
+  if (nc == 0U) {
+    switch (gate) {
+    case qc::I:
+    case qc::H:
+    case qc::X:
+    case qc::Y:
+    case qc::Z:
+    case qc::S:
+    case qc::Sdag:
+    case qc::T:
+    case qc::Tdag:
+    case qc::Phase:
+    case qc::U2:
+    case qc::U3:
+    case qc::SX:
+    case qc::SXdag:
+    case qc::V:
+    case qc::Vdag:
+    case qc::RX:
+    case qc::RY:
+    case qc::RZ:
+    // the following are merely placeholders so that the check can advance
+    case qc::Compound:
+    case qc::Measure:
+    case qc::Reset:
+    case qc::Snapshot:
+    case qc::ShowProbabilities:
+    case qc::Barrier:
+    case qc::ClassicControlled:
+      return 1U;
+    default:
+      break;
+    }
+  }
+
+  // special treatment for CNOT
+  if ((gate == qc::X) && (nc == 1U)) {
+    return 1U;
+  }
+
+  switch (gate) {
+  case qc::X:
+    return 2UL * (nc - 2UL) *
+               ((2UL * LegacyIBMCostFunction({qc::Phase, 0})) +
+                (2UL * LegacyIBMCostFunction({qc::U2, 0})) +
+                (3UL * LegacyIBMCostFunction({qc::X, 1}))) +
+           (6UL * LegacyIBMCostFunction({qc::X, 1})) +
+           (8UL * LegacyIBMCostFunction({qc::U3, 0}));
+  case qc::U3:
+  case qc::U2:
+  case qc::V:
+  case qc::Vdag:
+  case qc::RX:
+  case qc::RY:
+  case qc::H:
+  case qc::SX:
+  case qc::SXdag:
+    // heuristic
+    return (2U * LegacyIBMCostFunction({qc::X, nc})) +
+           (4U * LegacyIBMCostFunction({qc::U3, 0}));
+  case qc::Phase:
+  case qc::S:
+  case qc::Sdag:
+  case qc::T:
+  case qc::Tdag:
+  case qc::RZ:
+    // heuristic
+    return (2U * LegacyIBMCostFunction({qc::X, nc})) +
+           (3U * LegacyIBMCostFunction({qc::Phase, 0}));
+  case qc::Y:
+  case qc::Z:
+    return LegacyIBMCostFunction({qc::X, nc}) +
+           (2U * LegacyIBMCostFunction({qc::U3, 0}));
+  case qc::SWAP:
+    return LegacyIBMCostFunction({qc::X, nc}) +
+           (2U * LegacyIBMCostFunction({qc::X, 1}));
+  case qc::iSWAP:
+    return (2U * LegacyIBMCostFunction({qc::X, nc + 1U})) +
+           (2U * LegacyIBMCostFunction({qc::S, nc})) +
+           (2U * LegacyIBMCostFunction({qc::H, nc}));
+  case qc::Peres:
+  case qc::Peresdag:
+    return LegacyIBMCostFunction({qc::X, nc + 1U}) +
+           LegacyIBMCostFunction({qc::X, nc});
+  default:
+    return 1U;
+  }
+}
 } // namespace ec

--- a/include/checker/dd/applicationscheme/LookaheadApplicationScheme.hpp
+++ b/include/checker/dd/applicationscheme/LookaheadApplicationScheme.hpp
@@ -1,6 +1,6 @@
 //
-// This file is part of MQT QCEC library which is released under the MIT license.
-// See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
 #pragma once
@@ -8,78 +8,83 @@
 #include "ApplicationScheme.hpp"
 
 namespace ec {
-    template<class DDPackage = dd::Package<>>
-    class LookaheadApplicationScheme final: public ApplicationScheme<qc::MatrixDD, DDPackage> {
-    public:
-        LookaheadApplicationScheme(TaskManager<qc::MatrixDD, DDPackage>& taskManager1, TaskManager<qc::MatrixDD, DDPackage>& taskManager2) noexcept:
-            ApplicationScheme<qc::MatrixDD, DDPackage>(taskManager1, taskManager2) {}
+template <class DDPackage = dd::Package<>>
+class LookaheadApplicationScheme final
+    : public ApplicationScheme<qc::MatrixDD, DDPackage> {
+public:
+  LookaheadApplicationScheme(
+      TaskManager<qc::MatrixDD, DDPackage>& taskManager1,
+      TaskManager<qc::MatrixDD, DDPackage>& taskManager2) noexcept
+      : ApplicationScheme<qc::MatrixDD, DDPackage>(taskManager1, taskManager2) {
+  }
 
-        void setInternalState(qc::MatrixDD& state) noexcept {
-            internalState = &state;
-        }
-        void setPackage(DDPackage* dd) noexcept {
-            package = dd;
-        }
+  void setInternalState(qc::MatrixDD& state) noexcept {
+    internalState = &state;
+  }
+  void setPackage(DDPackage* dd) noexcept { package = dd; }
 
-        // in general, the lookup application scheme will apply a single operation of either circuit for every invocation.
-        // manipulation of the state is handled directly by the application scheme. Thus, the return value is always {0,0}.
-        std::pair<size_t, size_t> operator()() override {
-            assert(internalState != nullptr);
-            assert(package != nullptr);
+  // in general, the lookup application scheme will apply a single operation of
+  // either circuit for every invocation. manipulation of the state is handled
+  // directly by the application scheme. Thus, the return value is always {0,0}.
+  std::pair<size_t, size_t> operator()() override {
+    assert(internalState != nullptr);
+    assert(package != nullptr);
 
-            if (!cached1) {
-                // cache the current operation
-                op1 = this->taskManager1.getDD();
-                package->incRef(op1);
-                cached1 = true;
-            }
+    if (!cached1) {
+      // cache the current operation
+      op1 = this->taskManager1.getDD();
+      package->incRef(op1);
+      cached1 = true;
+    }
 
-            if (!cached2) {
-                // cache the current operation
-                op2 = this->taskManager2.getInverseDD();
-                package->incRef(op2);
-                cached2 = true;
-            }
+    if (!cached2) {
+      // cache the current operation
+      op2 = this->taskManager2.getInverseDD();
+      package->incRef(op2);
+      cached2 = true;
+    }
 
-            // compute both possible applications and measure the resulting size
-            auto       saved = *internalState;
-            const auto dd1   = package->multiply(op1, saved);
-            const auto size1 = package->size(dd1);
-            const auto dd2   = package->multiply(saved, op2);
+    // compute both possible applications and measure the resulting size
+    auto       saved = *internalState;
+    const auto dd1   = package->multiply(op1, saved);
+    const auto size1 = package->size(dd1);
+    const auto dd2   = package->multiply(saved, op2);
 
-            // greedily chose the smaller resulting decision diagram
-            if (const auto size2 = package->size(dd2); size1 <= size2) {
-                assert(!this->taskManager1.finished());
-                *internalState = dd1;
-                package->decRef(op1);
-                cached1 = false;
-                this->taskManager1.advanceIterator();
-            } else {
-                assert(!this->taskManager2.finished());
-                *internalState = dd2;
-                package->decRef(op2);
-                cached2 = false;
-                this->taskManager2.advanceIterator();
-            }
+    // greedily chose the smaller resulting decision diagram
+    if (const auto size2 = package->size(dd2); size1 <= size2) {
+      assert(!this->taskManager1.finished());
+      *internalState = dd1;
+      package->decRef(op1);
+      cached1 = false;
+      this->taskManager1.advanceIterator();
+    } else {
+      assert(!this->taskManager2.finished());
+      *internalState = dd2;
+      package->decRef(op2);
+      cached2 = false;
+      this->taskManager2.advanceIterator();
+    }
 
-            // properly track reference counts
-            package->incRef(*internalState);
-            package->decRef(saved);
-            package->garbageCollect();
+    // properly track reference counts
+    package->incRef(*internalState);
+    package->decRef(saved);
+    package->garbageCollect();
 
-            // no operations shall be applied by the outer loop in which the application scheme is invoked
-            return {0U, 0U};
-        }
+    // no operations shall be applied by the outer loop in which the application
+    // scheme is invoked
+    return {0U, 0U};
+  }
 
-    private:
-        qc::MatrixDD op1{};
-        bool         cached1 = false;
+private:
+  qc::MatrixDD op1{};
+  bool         cached1 = false;
 
-        qc::MatrixDD op2{};
-        bool         cached2 = false;
+  qc::MatrixDD op2{};
+  bool         cached2 = false;
 
-        // the lookahead application scheme maintains links to an internal state to manipulate and a package to use
-        qc::MatrixDD* internalState{};
-        DDPackage*    package{};
-    };
+  // the lookahead application scheme maintains links to an internal state to
+  // manipulate and a package to use
+  qc::MatrixDD* internalState{};
+  DDPackage*    package{};
+};
 } // namespace ec

--- a/include/checker/dd/applicationscheme/OneToOneApplicationScheme.hpp
+++ b/include/checker/dd/applicationscheme/OneToOneApplicationScheme.hpp
@@ -1,6 +1,6 @@
 //
-// This file is part of MQT QCEC library which is released under the MIT license.
-// See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
 #pragma once
@@ -8,14 +8,15 @@
 #include "ApplicationScheme.hpp"
 
 namespace ec {
-    template<class DDType, class DDPackage = dd::Package<>>
-    class OneToOneApplicationScheme final: public ApplicationScheme<DDType, DDPackage> {
-    public:
-        OneToOneApplicationScheme(TaskManager<DDType, DDPackage>& taskManager1, TaskManager<DDType, DDPackage>& taskManager2) noexcept:
-            ApplicationScheme<DDType, DDPackage>(taskManager1, taskManager2) {}
+template <class DDType, class DDPackage = dd::Package<>>
+class OneToOneApplicationScheme final
+    : public ApplicationScheme<DDType, DDPackage> {
+public:
+  OneToOneApplicationScheme(
+      TaskManager<DDType, DDPackage>& taskManager1,
+      TaskManager<DDType, DDPackage>& taskManager2) noexcept
+      : ApplicationScheme<DDType, DDPackage>(taskManager1, taskManager2) {}
 
-        std::pair<size_t, size_t> operator()() noexcept override {
-            return {1U, 1U};
-        }
-    };
+  std::pair<size_t, size_t> operator()() noexcept override { return {1U, 1U}; }
+};
 } // namespace ec

--- a/include/checker/dd/applicationscheme/ProportionalApplicationScheme.hpp
+++ b/include/checker/dd/applicationscheme/ProportionalApplicationScheme.hpp
@@ -1,6 +1,6 @@
 //
-// This file is part of MQT QCEC library which is released under the MIT license.
-// See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
 #pragma once
@@ -8,24 +8,27 @@
 #include "ApplicationScheme.hpp"
 
 namespace ec {
-    template<class DDType, class DDPackage = dd::Package<>>
-    class ProportionalApplicationScheme final: public ApplicationScheme<DDType, DDPackage> {
-    public:
-        ProportionalApplicationScheme(TaskManager<DDType, DDPackage>& taskManager1, TaskManager<DDType, DDPackage>& taskManager2):
-            ApplicationScheme<DDType, DDPackage>(taskManager1, taskManager2),
-            gateRatio(computeGateRatio()) {}
+template <class DDType, class DDPackage = dd::Package<>>
+class ProportionalApplicationScheme final
+    : public ApplicationScheme<DDType, DDPackage> {
+public:
+  ProportionalApplicationScheme(TaskManager<DDType, DDPackage>& taskManager1,
+                                TaskManager<DDType, DDPackage>& taskManager2)
+      : ApplicationScheme<DDType, DDPackage>(taskManager1, taskManager2),
+        gateRatio(computeGateRatio()) {}
 
-        std::pair<size_t, size_t> operator()() noexcept override {
-            return {1U, gateRatio};
-        }
+  std::pair<size_t, size_t> operator()() noexcept override {
+    return {1U, gateRatio};
+  }
 
-    private:
-        [[nodiscard]] std::size_t computeGateRatio() const noexcept {
-            const std::size_t size1 = this->taskManager1.getCircuit()->size();
-            const std::size_t size2 = this->taskManager2.getCircuit()->size();
-            return std::max((size2 + (size1 / 2U)) / size1, static_cast<std::size_t>(1U));
-        }
+private:
+  [[nodiscard]] std::size_t computeGateRatio() const noexcept {
+    const std::size_t size1 = this->taskManager1.getCircuit()->size();
+    const std::size_t size2 = this->taskManager2.getCircuit()->size();
+    return std::max((size2 + (size1 / 2U)) / size1,
+                    static_cast<std::size_t>(1U));
+  }
 
-        const std::size_t gateRatio;
-    };
+  const std::size_t gateRatio;
+};
 } // namespace ec

--- a/include/checker/dd/applicationscheme/SequentialApplicationScheme.hpp
+++ b/include/checker/dd/applicationscheme/SequentialApplicationScheme.hpp
@@ -1,6 +1,6 @@
 //
-// This file is part of MQT QCEC library which is released under the MIT license.
-// See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
 #pragma once
@@ -8,20 +8,23 @@
 #include "ApplicationScheme.hpp"
 
 namespace ec {
-    template<class DDType, class DDPackage = dd::Package<>>
-    class SequentialApplicationScheme final: public ApplicationScheme<DDType, DDPackage> {
-    public:
-        SequentialApplicationScheme(TaskManager<DDType, DDPackage>& taskManager1, TaskManager<DDType, DDPackage>& taskManager2) noexcept:
-            ApplicationScheme<DDType, DDPackage>(taskManager1, taskManager2),
-            gates1(taskManager1.getCircuit()->getNops()),
-            gates2(taskManager2.getCircuit()->getNops()) {}
+template <class DDType, class DDPackage = dd::Package<>>
+class SequentialApplicationScheme final
+    : public ApplicationScheme<DDType, DDPackage> {
+public:
+  SequentialApplicationScheme(
+      TaskManager<DDType, DDPackage>& taskManager1,
+      TaskManager<DDType, DDPackage>& taskManager2) noexcept
+      : ApplicationScheme<DDType, DDPackage>(taskManager1, taskManager2),
+        gates1(taskManager1.getCircuit()->getNops()),
+        gates2(taskManager2.getCircuit()->getNops()) {}
 
-        std::pair<size_t, size_t> operator()() noexcept override {
-            return {gates1, gates2};
-        }
+  std::pair<size_t, size_t> operator()() noexcept override {
+    return {gates1, gates2};
+  }
 
-    private:
-        const std::size_t gates1;
-        const std::size_t gates2;
-    };
+private:
+  const std::size_t gates1;
+  const std::size_t gates2;
+};
 } // namespace ec

--- a/include/checker/dd/simulation/StateGenerator.hpp
+++ b/include/checker/dd/simulation/StateGenerator.hpp
@@ -1,6 +1,6 @@
 //
-// This file is part of MQT QCEC library which is released under the MIT license.
-// See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
 #pragma once
@@ -15,152 +15,180 @@
 #include <random>
 
 namespace ec {
-    class StateGenerator {
-    public:
-        explicit StateGenerator(const std::size_t seed):
-            seed(seed) {
-            seedGenerator(seed);
+class StateGenerator {
+public:
+  explicit StateGenerator(const std::size_t seed) : seed(seed) {
+    seedGenerator(seed);
+  }
+  StateGenerator() : StateGenerator(0U) {}
+
+  template <class DDPackage = dd::Package<>>
+  qc::VectorDD
+  generateRandomState(std::unique_ptr<DDPackage>& dd,
+                      const dd::QubitCount        totalQubits,
+                      const dd::QubitCount        ancillaryQubits = 0U,
+                      const StateType type = StateType::ComputationalBasis) {
+    switch (type) {
+    case ec::StateType::Random1QBasis:
+      return generateRandom1QBasisState(dd, totalQubits, ancillaryQubits);
+    case ec::StateType::Stabilizer:
+      return generateRandomStabilizerState(dd, totalQubits, ancillaryQubits);
+    default:
+      return generateRandomComputationalBasisState(dd, totalQubits,
+                                                   ancillaryQubits);
+    }
+  }
+
+  template <class DDPackage = dd::Package<>>
+  qc::VectorDD generateRandomComputationalBasisState(
+      std::unique_ptr<DDPackage>& dd, const dd::QubitCount totalQubits,
+      const dd::QubitCount ancillaryQubits = 0U) {
+    // determine how many qubits truly are random
+    const std::size_t randomQubits = totalQubits - ancillaryQubits;
+    std::vector<bool> stimulusBits(totalQubits, false);
+
+    // check if there still is a unique computational basis state
+    if (constexpr auto bitwidth =
+            std::numeric_limits<std::uint_least64_t>::digits;
+        randomQubits <= (bitwidth - 1U)) {
+      const auto maxStates = static_cast<std::uint_least64_t>(1U)
+                             << randomQubits;
+      assert(generatedComputationalBasisStates.size() != maxStates);
+      // generate a unique computational basis state
+      std::uniform_int_distribution<std::uint_least64_t> distribution(
+          0, maxStates - 1);
+      auto [randomState, success] =
+          generatedComputationalBasisStates.insert(distribution(mt));
+      while (!success) {
+        std::tie(randomState, success) =
+            generatedComputationalBasisStates.insert(distribution(mt));
+      }
+
+      // generate the bitvector corresponding to the random state
+      for (std::size_t i = 0U; i < randomQubits; ++i) {
+        if ((*randomState & (static_cast<std::uint_least64_t>(1U) << i)) !=
+            0U) {
+          stimulusBits[i] = true;
         }
-        StateGenerator():
-            StateGenerator(0U) {}
-
-        template<class DDPackage = dd::Package<>>
-        qc::VectorDD generateRandomState(std::unique_ptr<DDPackage>& dd, const dd::QubitCount totalQubits, const dd::QubitCount ancillaryQubits = 0U, const StateType type = StateType::ComputationalBasis) {
-            switch (type) {
-                case ec::StateType::Random1QBasis:
-                    return generateRandom1QBasisState(dd, totalQubits, ancillaryQubits);
-                case ec::StateType::Stabilizer:
-                    return generateRandomStabilizerState(dd, totalQubits, ancillaryQubits);
-                default:
-                    return generateRandomComputationalBasisState(dd, totalQubits, ancillaryQubits);
-            }
+      }
+    } else {
+      // check how many numbers are needed for each random state
+      const auto nr = static_cast<std::size_t>(
+          std::ceil(static_cast<double>(randomQubits) / bitwidth));
+      // generate enough random numbers
+      std::vector<std::mt19937_64::result_type> randomNumbers(nr, 0U);
+      for (auto i = 0U; i < nr; ++i) {
+        randomNumbers[i] = mt();
+      }
+      // generate the corresponding bitvector
+      for (std::size_t i = 0U; i < randomQubits; ++i) {
+        if ((randomNumbers[i / bitwidth] &
+             (static_cast<std::uint_least64_t>(1U) << (i % bitwidth))) != 0U) {
+          stimulusBits[i] = true;
         }
+      }
+    }
 
-        template<class DDPackage = dd::Package<>>
-        qc::VectorDD generateRandomComputationalBasisState(std::unique_ptr<DDPackage>& dd, const dd::QubitCount totalQubits, const dd::QubitCount ancillaryQubits = 0U) {
-            // determine how many qubits truly are random
-            const std::size_t randomQubits = totalQubits - ancillaryQubits;
-            std::vector<bool> stimulusBits(totalQubits, false);
+    // return the appropriate decision diagram
+    return dd->makeBasisState(totalQubits, stimulusBits);
+  }
 
-            // check if there still is a unique computational basis state
-            if (constexpr auto bitwidth = std::numeric_limits<std::uint_least64_t>::digits; randomQubits <= (bitwidth - 1U)) {
-                const auto maxStates = static_cast<std::uint_least64_t>(1U) << randomQubits;
-                assert(generatedComputationalBasisStates.size() != maxStates);
-                // generate a unique computational basis state
-                std::uniform_int_distribution<std::uint_least64_t> distribution(0, maxStates - 1);
-                auto [randomState, success] = generatedComputationalBasisStates.insert(distribution(mt));
-                while (!success) {
-                    std::tie(randomState, success) = generatedComputationalBasisStates.insert(distribution(mt));
-                }
+  template <class DDPackage = dd::Package<>>
+  qc::VectorDD
+  generateRandom1QBasisState(std::unique_ptr<DDPackage>& dd,
+                             const dd::QubitCount        totalQubits,
+                             const dd::QubitCount        ancillaryQubits = 0U) {
+    // determine how many qubits truly are random
+    const auto randomQubits = totalQubits - ancillaryQubits;
 
-                // generate the bitvector corresponding to the random state
-                for (std::size_t i = 0U; i < randomQubits; ++i) {
-                    if ((*randomState & (static_cast<std::uint_least64_t>(1U) << i)) != 0U) {
-                        stimulusBits[i] = true;
-                    }
-                }
-            } else {
-                // check how many numbers are needed for each random state
-                const auto nr = static_cast<std::size_t>(std::ceil(static_cast<double>(randomQubits) / bitwidth));
-                // generate enough random numbers
-                std::vector<std::mt19937_64::result_type> randomNumbers(nr, 0U);
-                for (auto i = 0U; i < nr; ++i) {
-                    randomNumbers[i] = mt();
-                }
-                // generate the corresponding bitvector
-                for (std::size_t i = 0U; i < randomQubits; ++i) {
-                    if ((randomNumbers[i / bitwidth] & (static_cast<std::uint_least64_t>(1U) << (i % bitwidth))) != 0U) {
-                        stimulusBits[i] = true;
-                    }
-                }
-            }
+    // choose a random basis state for each qubit
+    auto randomBasisState =
+        std::vector<dd::BasisStates>(totalQubits, dd::BasisStates::zero);
+    for (dd::QubitCount i = 0U; i < randomQubits; ++i) {
+      switch (random1QBasisDistribution(mt)) {
+      case static_cast<std::size_t>(dd::BasisStates::zero):
+        randomBasisState[i] = dd::BasisStates::zero;
+        break;
+      case static_cast<std::size_t>(dd::BasisStates::one):
+        randomBasisState[i] = dd::BasisStates::one;
+        break;
+      case static_cast<std::size_t>(dd::BasisStates::plus):
+        randomBasisState[i] = dd::BasisStates::plus;
+        break;
+      case static_cast<std::size_t>(dd::BasisStates::minus):
+        randomBasisState[i] = dd::BasisStates::minus;
+        break;
+      case static_cast<std::size_t>(dd::BasisStates::right):
+        randomBasisState[i] = dd::BasisStates::right;
+        break;
+      case static_cast<std::size_t>(dd::BasisStates::left):
+        randomBasisState[i] = dd::BasisStates::left;
+        break;
+      default:
+        break;
+      }
+    }
 
-            // return the appropriate decision diagram
-            return dd->makeBasisState(totalQubits, stimulusBits);
-        }
+    // return the appropriate decision diagram
+    return dd->makeBasisState(totalQubits, randomBasisState);
+  }
 
-        template<class DDPackage = dd::Package<>>
-        qc::VectorDD generateRandom1QBasisState(std::unique_ptr<DDPackage>& dd, const dd::QubitCount totalQubits, const dd::QubitCount ancillaryQubits = 0U) {
-            // determine how many qubits truly are random
-            const auto randomQubits = totalQubits - ancillaryQubits;
+  template <class DDPackage = dd::Package<>>
+  qc::VectorDD
+  generateRandomStabilizerState(std::unique_ptr<DDPackage>& dd,
+                                const dd::QubitCount        totalQubits,
+                                const dd::QubitCount ancillaryQubits = 0U) {
+    // determine how many qubits truly are random
+    const dd::QubitCount randomQubits = totalQubits - ancillaryQubits;
 
-            // choose a random basis state for each qubit
-            auto randomBasisState = std::vector<dd::BasisStates>(totalQubits, dd::BasisStates::zero);
-            for (dd::QubitCount i = 0U; i < randomQubits; ++i) {
-                switch (random1QBasisDistribution(mt)) {
-                    case static_cast<std::size_t>(dd::BasisStates::zero):
-                        randomBasisState[i] = dd::BasisStates::zero;
-                        break;
-                    case static_cast<std::size_t>(dd::BasisStates::one):
-                        randomBasisState[i] = dd::BasisStates::one;
-                        break;
-                    case static_cast<std::size_t>(dd::BasisStates::plus):
-                        randomBasisState[i] = dd::BasisStates::plus;
-                        break;
-                    case static_cast<std::size_t>(dd::BasisStates::minus):
-                        randomBasisState[i] = dd::BasisStates::minus;
-                        break;
-                    case static_cast<std::size_t>(dd::BasisStates::right):
-                        randomBasisState[i] = dd::BasisStates::right;
-                        break;
-                    case static_cast<std::size_t>(dd::BasisStates::left):
-                        randomBasisState[i] = dd::BasisStates::left;
-                        break;
-                    default:
-                        break;
-                }
-            }
+    // generate a random Clifford circuit with appropriate depth
+    auto rcs = qc::RandomCliffordCircuit(
+        randomQubits,
+        static_cast<std::size_t>(std::round(std::log2(randomQubits))), mt());
 
-            // return the appropriate decision diagram
-            return dd->makeBasisState(totalQubits, randomBasisState);
-        }
+    // generate the associated stabilizer state by simulating the Clifford
+    // circuit
+    auto stabilizer = simulate(&rcs, dd->makeZeroState(randomQubits), dd);
 
-        template<class DDPackage = dd::Package<>>
-        qc::VectorDD generateRandomStabilizerState(std::unique_ptr<DDPackage>& dd, const dd::QubitCount totalQubits, const dd::QubitCount ancillaryQubits = 0U) {
-            // determine how many qubits truly are random
-            const dd::QubitCount randomQubits = totalQubits - ancillaryQubits;
+    // decrease the ref count right after so that it stays correct later on
+    dd->decRef(stabilizer);
 
-            // generate a random Clifford circuit with appropriate depth
-            auto rcs = qc::RandomCliffordCircuit(randomQubits, static_cast<std::size_t>(std::round(std::log2(randomQubits))), mt());
+    // add |0> edges for all the ancillary qubits
+    auto initial = stabilizer;
+    for (dd::QubitCount p = randomQubits; p < totalQubits; ++p) {
+      initial = dd->makeDDNode(static_cast<dd::Qubit>(p),
+                               std::array{initial, qc::VectorDD::zero});
+    }
 
-            // generate the associated stabilizer state by simulating the Clifford circuit
-            auto stabilizer = simulate(&rcs, dd->makeZeroState(randomQubits), dd);
+    // return the resulting decision diagram
+    return initial;
+  }
 
-            // decrease the ref count right after so that it stays correct later on
-            dd->decRef(stabilizer);
+  void seedGenerator(const std::size_t s) {
+    seed = s;
+    if (seed == 0U) {
+      std::array<std::mt19937_64::result_type, std::mt19937_64::state_size>
+                         randomData{};
+      std::random_device rd;
+      std::generate(std::begin(randomData), std::end(randomData), std::ref(rd));
+      std::seed_seq seeds(std::begin(randomData), std::end(randomData));
+      mt.seed(seeds);
+    } else {
+      mt.seed(seed);
+    }
+  }
 
-            // add |0> edges for all the ancillary qubits
-            auto initial = stabilizer;
-            for (dd::QubitCount p = randomQubits; p < totalQubits; ++p) {
-                initial = dd->makeDDNode(static_cast<dd::Qubit>(p), std::array{initial, qc::VectorDD::zero});
-            }
+  void clear() { generatedComputationalBasisStates.clear(); }
 
-            // return the resulting decision diagram
-            return initial;
-        }
+private:
+  std::size_t     seed = 0U;
+  std::mt19937_64 mt;
 
-        void seedGenerator(const std::size_t s) {
-            seed = s;
-            if (seed == 0U) {
-                std::array<std::mt19937_64::result_type, std::mt19937_64::state_size> randomData{};
-                std::random_device                                                    rd;
-                std::generate(std::begin(randomData), std::end(randomData), std::ref(rd));
-                std::seed_seq seeds(std::begin(randomData), std::end(randomData));
-                mt.seed(seeds);
-            } else {
-                mt.seed(seed);
-            }
-        }
-
-        void clear() { generatedComputationalBasisStates.clear(); }
-
-    private:
-        std::size_t     seed = 0U;
-        std::mt19937_64 mt;
-
-        std::unordered_set<std::size_t> generatedComputationalBasisStates{};
-        constexpr static std::size_t    OneQubitBaseElements = 6U;
-        // this generator produces random bases from the set { |0>, |1>, |+>, |->, |L>, |R> }
-        std::uniform_int_distribution<std::size_t> random1QBasisDistribution = std::uniform_int_distribution<std::size_t>(0U, OneQubitBaseElements - 1U);
-    };
+  std::unordered_set<std::size_t> generatedComputationalBasisStates{};
+  constexpr static std::size_t    OneQubitBaseElements = 6U;
+  // this generator produces random bases from the set { |0>, |1>, |+>, |->,
+  // |L>, |R> }
+  std::uniform_int_distribution<std::size_t> random1QBasisDistribution =
+      std::uniform_int_distribution<std::size_t>(0U, OneQubitBaseElements - 1U);
+};
 } // namespace ec

--- a/include/checker/dd/simulation/StateType.hpp
+++ b/include/checker/dd/simulation/StateType.hpp
@@ -1,6 +1,6 @@
 //
-// This file is part of MQT QCEC library which is released under the MIT license.
-// See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
 #pragma once
@@ -8,52 +8,55 @@
 #include <iostream>
 
 namespace ec {
-    enum class StateType {
-        ComputationalBasis = 0,
-        Random1QBasis      = 1,
-        Stabilizer         = 2
-    };
+enum class StateType {
+  ComputationalBasis = 0,
+  Random1QBasis      = 1,
+  Stabilizer         = 2
+};
 
-    inline std::string toString(const StateType& type) noexcept {
-        switch (type) {
-            case StateType::Random1QBasis:
-                return "random_1Q_basis";
-            case StateType::Stabilizer:
-                return "stabilizer";
-            default:
-                return "computational_basis";
-        }
-    }
+inline std::string toString(const StateType& type) noexcept {
+  switch (type) {
+  case StateType::Random1QBasis:
+    return "random_1Q_basis";
+  case StateType::Stabilizer:
+    return "stabilizer";
+  default:
+    return "computational_basis";
+  }
+}
 
-    inline StateType stateTypeFromString(const std::string& type) noexcept {
-        if ((type == "computational_basis") || (type == "0") || (type == "classical")) {
-            return StateType::ComputationalBasis;
-        }
-        if ((type == "random_1Q_basis") || (type == "1") || (type == "local_quantum")) {
-            return StateType::Random1QBasis;
-        }
-        if ((type == "stabilizer") || (type == "2") || (type == "global_quantum")) {
-            return StateType::Stabilizer;
-        }
-        std::cerr << "Unknown state type: " << type << ". Defaulting to computational basis states.\n";
-        return StateType::ComputationalBasis;
-    }
+inline StateType stateTypeFromString(const std::string& type) noexcept {
+  if ((type == "computational_basis") || (type == "0") ||
+      (type == "classical")) {
+    return StateType::ComputationalBasis;
+  }
+  if ((type == "random_1Q_basis") || (type == "1") ||
+      (type == "local_quantum")) {
+    return StateType::Random1QBasis;
+  }
+  if ((type == "stabilizer") || (type == "2") || (type == "global_quantum")) {
+    return StateType::Stabilizer;
+  }
+  std::cerr << "Unknown state type: " << type
+            << ". Defaulting to computational basis states.\n";
+  return StateType::ComputationalBasis;
+}
 
-    inline std::istream& operator>>(std::istream& in, StateType& type) {
-        std::string token;
-        in >> token;
+inline std::istream& operator>>(std::istream& in, StateType& type) {
+  std::string token;
+  in >> token;
 
-        if (token.empty()) {
-            in.setstate(std::istream::failbit);
-            return in;
-        }
+  if (token.empty()) {
+    in.setstate(std::istream::failbit);
+    return in;
+  }
 
-        type = stateTypeFromString(token);
-        return in;
-    }
+  type = stateTypeFromString(token);
+  return in;
+}
 
-    inline std::ostream& operator<<(std::ostream& out, const StateType& type) {
-        out << toString(type);
-        return out;
-    }
+inline std::ostream& operator<<(std::ostream& out, const StateType& type) {
+  out << toString(type);
+  return out;
+}
 } // namespace ec

--- a/include/checker/zx/ZXChecker.hpp
+++ b/include/checker/zx/ZXChecker.hpp
@@ -1,3 +1,8 @@
+//
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
+//
+
 #pragma once
 
 #include "Configuration.hpp"
@@ -10,96 +15,99 @@
 #include "nlohmann/json.hpp"
 
 namespace ec {
-    class ZXEquivalenceChecker: public EquivalenceChecker {
-    public:
-        ZXEquivalenceChecker(const qc::QuantumComputation& qc1, const qc::QuantumComputation& qc2, Configuration configuration) noexcept;
+class ZXEquivalenceChecker : public EquivalenceChecker {
+public:
+  ZXEquivalenceChecker(const qc::QuantumComputation& qc1,
+                       const qc::QuantumComputation& qc2,
+                       Configuration                 configuration) noexcept;
 
-        EquivalenceCriterion run() override;
+  EquivalenceCriterion run() override;
 
-        void json(nlohmann::json& j) const noexcept override {
-            EquivalenceChecker::json(j);
-            j["checker"] = "zx";
+  void json(nlohmann::json& j) const noexcept override {
+    EquivalenceChecker::json(j);
+    j["checker"] = "zx";
+  }
+
+private:
+  zx::ZXDiagram miter;
+  zx::fp        tolerance;
+  bool          ancilla = false;
+
+  // the following methods are adaptations of the core ZX simplification
+  // routines that additionally check a criterion for early termination of the
+  // simplification.
+  std::size_t fullReduceApproximate();
+  std::size_t fullReduce();
+
+  std::size_t gadgetSimp();
+  std::size_t interiorCliffordSimp();
+  std::size_t cliffordSimp();
+
+  std::size_t idSimp() {
+    return simplifyVertices(zx::checkIdSimp, zx::removeId);
+  }
+
+  std::size_t spiderSimp() {
+    return simplifyEdges(zx::checkSpiderFusion, zx::fuseSpiders);
+  }
+
+  std::size_t localCompSimp() {
+    return simplifyVertices(zx::checkLocalComp, zx::localComp);
+  }
+
+  std::size_t pivotPauliSimp() {
+    return simplifyEdges(zx::checkPivotPauli, zx::pivotPauli);
+  }
+
+  std::size_t pivotSimp() { return simplifyEdges(zx::checkPivot, zx::pivot); }
+
+  std::size_t pivotGadgetSimp() {
+    return simplifyEdges(zx::checkPivotGadget, zx::pivotGadget);
+  }
+
+  template <class CheckFun = zx::VertexCheckFun,
+            class RuleFun  = zx::VertexRuleFun>
+  std::size_t simplifyVertices(CheckFun check, RuleFun rule) {
+    std::size_t nSimplifications = 0;
+    bool        newMatches       = true;
+
+    while (!isDone() && newMatches) {
+      newMatches = false;
+      for (const auto& [v, _] : miter.getVertices()) {
+        if (isDone() || !check(miter, v)) {
+          continue;
         }
+        rule(miter, v);
+        newMatches = true;
+        ++nSimplifications;
+      }
+    }
+    return nSimplifications;
+  }
 
-    private:
-        zx::ZXDiagram miter;
-        zx::fp        tolerance;
-        bool          ancilla = false;
+  template <class CheckFun = zx::EdgeCheckFun, class RuleFun = zx::EdgeRuleFun>
+  std::size_t simplifyEdges(CheckFun check, RuleFun rule) {
+    std::size_t nSimplifications = 0;
+    bool        newMatches       = true;
 
-        // the following methods are adaptations of the core ZX simplification routines
-        // that additionally check a criterion for early termination of the simplification.
-        std::size_t fullReduceApproximate();
-        std::size_t fullReduce();
-
-        std::size_t gadgetSimp();
-        std::size_t interiorCliffordSimp();
-        std::size_t cliffordSimp();
-
-        std::size_t idSimp() {
-            return simplifyVertices(zx::checkIdSimp, zx::removeId);
+    while (!isDone() && newMatches) {
+      newMatches = false;
+      for (const auto& [v0, v1] : miter.getEdges()) {
+        if (isDone() || miter.isDeleted(v0) || miter.isDeleted(v1) ||
+            !check(miter, v0, v1)) {
+          continue;
         }
+        rule(miter, v0, v1);
+        newMatches = true;
+        ++nSimplifications;
+      }
+    }
+    return nSimplifications;
+  }
+};
 
-        std::size_t spiderSimp() {
-            return simplifyEdges(zx::checkSpiderFusion, zx::fuseSpiders);
-        }
-
-        std::size_t localCompSimp() {
-            return simplifyVertices(zx::checkLocalComp, zx::localComp);
-        }
-
-        std::size_t pivotPauliSimp() {
-            return simplifyEdges(zx::checkPivotPauli, zx::pivotPauli);
-        }
-
-        std::size_t pivotSimp() {
-            return simplifyEdges(zx::checkPivot, zx::pivot);
-        }
-
-        std::size_t pivotGadgetSimp() {
-            return simplifyEdges(zx::checkPivotGadget, zx::pivotGadget);
-        }
-
-        template<class CheckFun = zx::VertexCheckFun, class RuleFun = zx::VertexRuleFun>
-        std::size_t simplifyVertices(CheckFun check, RuleFun rule) {
-            std::size_t nSimplifications = 0;
-            bool        newMatches       = true;
-
-            while (!isDone() && newMatches) {
-                newMatches = false;
-                for (const auto& [v, _]: miter.getVertices()) {
-                    if (isDone() || !check(miter, v)) {
-                        continue;
-                    }
-                    rule(miter, v);
-                    newMatches = true;
-                    ++nSimplifications;
-                }
-            }
-            return nSimplifications;
-        }
-
-        template<class CheckFun = zx::EdgeCheckFun, class RuleFun = zx::EdgeRuleFun>
-        std::size_t simplifyEdges(CheckFun check, RuleFun rule) {
-            std::size_t nSimplifications = 0;
-            bool        newMatches       = true;
-
-            while (!isDone() && newMatches) {
-                newMatches = false;
-                for (const auto& [v0, v1]: miter.getEdges()) {
-                    if (isDone() || miter.isDeleted(v0) || miter.isDeleted(v1) || !check(miter, v0, v1)) {
-                        continue;
-                    }
-                    rule(miter, v0, v1);
-                    newMatches = true;
-                    ++nSimplifications;
-                }
-            }
-            return nSimplifications;
-        }
-    };
-
-    qc::Permutation complete(const qc::Permutation& p, dd::QubitCount n);
-    qc::Permutation concat(const qc::Permutation& p1, const qc::Permutation& p2);
-    qc::Permutation invert(const qc::Permutation& p);
-    qc::Permutation invertPermutations(const qc::QuantumComputation& qc);
+qc::Permutation complete(const qc::Permutation& p, dd::QubitCount n);
+qc::Permutation concat(const qc::Permutation& p1, const qc::Permutation& p2);
+qc::Permutation invert(const qc::Permutation& p);
+qc::Permutation invertPermutations(const qc::QuantumComputation& qc);
 } // namespace ec

--- a/jkq/__init__.py
+++ b/jkq/__init__.py
@@ -1,3 +1,8 @@
+#
+# This file is part of the MQT QCEC library released under the MIT license.
+# See README.md or go to https://github.com/cda-tum/qcec for more information.
+#
+
 import warnings
 from mqt import qcec
 

--- a/mqt/qcec/__init__.py
+++ b/mqt/qcec/__init__.py
@@ -1,6 +1,6 @@
 #
-# This file is part of MQT QCEC library which is released under the MIT license.
-# See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+# This file is part of the MQT QCEC library released under the MIT license.
+# See README.md or go to https://github.com/cda-tum/qcec for more information.
 #
 
 from mqt.qcec.pyqcec import ApplicationScheme, StateType, EquivalenceCriterion, EquivalenceCheckingManager, Configuration, verify

--- a/mqt/qcec/bindings.cpp
+++ b/mqt/qcec/bindings.cpp
@@ -1,6 +1,6 @@
 //
-// This file is part of MQT QCEC library which is released under the MIT license.
-// See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
 #include "EquivalenceCheckingManager.hpp"
@@ -22,378 +22,728 @@ namespace nl = nlohmann;
 using namespace pybind11::literals;
 
 namespace ec {
-    qc::QuantumComputation importCircuit(const py::object& circ) {
-        py::object QuantumCircuit       = py::module::import("qiskit").attr("QuantumCircuit");
-        py::object pyQasmQobjExperiment = py::module::import("qiskit.qobj").attr("QasmQobjExperiment");
+qc::QuantumComputation importCircuit(const py::object& circ) {
+  py::object QuantumCircuit =
+      py::module::import("qiskit").attr("QuantumCircuit");
+  py::object pyQasmQobjExperiment =
+      py::module::import("qiskit.qobj").attr("QasmQobjExperiment");
 
-        auto qc = qc::QuantumComputation();
+  auto qc = qc::QuantumComputation();
 
-        if (py::isinstance<py::str>(circ)) {
-            auto&& file = circ.cast<std::string>();
-            qc.import(file);
-        } else if (py::isinstance(circ, QuantumCircuit)) {
-            qc::qiskit::QuantumCircuit::import(qc, circ);
-        } else if (py::isinstance(circ, pyQasmQobjExperiment)) {
-            qc::qiskit::QasmQobjExperiment::import(qc, circ);
-        } else {
-            throw std::runtime_error("PyObject is neither py::str, QuantumCircuit, nor QasmQobjExperiment");
-        }
+  if (py::isinstance<py::str>(circ)) {
+    auto&& file = circ.cast<std::string>();
+    qc.import(file);
+  } else if (py::isinstance(circ, QuantumCircuit)) {
+    qc::qiskit::QuantumCircuit::import(qc, circ);
+  } else if (py::isinstance(circ, pyQasmQobjExperiment)) {
+    qc::qiskit::QasmQobjExperiment::import(qc, circ);
+  } else {
+    throw std::runtime_error(
+        "PyObject is neither py::str, QuantumCircuit, nor QasmQobjExperiment");
+  }
 
-        return qc;
-    }
+  return qc;
+}
 
-    std::unique_ptr<EquivalenceCheckingManager> createManagerFromConfiguration(const py::object& circ1, const py::object& circ2, const Configuration& configuration) noexcept {
-        qc::QuantumComputation qc1;
-        try {
-            qc1 = importCircuit(circ1);
-        } catch (const std::exception& ex) {
-            std::cerr << "Could not import first circuit: " << ex.what() << std::endl;
-            return {};
-        }
+std::unique_ptr<EquivalenceCheckingManager>
+createManagerFromConfiguration(const py::object& circ1, const py::object& circ2,
+                               const Configuration& configuration) noexcept {
+  qc::QuantumComputation qc1;
+  try {
+    qc1 = importCircuit(circ1);
+  } catch (const std::exception& ex) {
+    std::cerr << "Could not import first circuit: " << ex.what() << std::endl;
+    return {};
+  }
 
-        qc::QuantumComputation qc2;
-        try {
-            qc2 = importCircuit(circ2);
-        } catch (const std::exception& ex) {
-            std::cerr << "Could not import second circuit: " << ex.what() << std::endl;
-            return {};
-        }
+  qc::QuantumComputation qc2;
+  try {
+    qc2 = importCircuit(circ2);
+  } catch (const std::exception& ex) {
+    std::cerr << "Could not import second circuit: " << ex.what() << std::endl;
+    return {};
+  }
 
-        try {
-            return std::make_unique<EquivalenceCheckingManager>(qc1, qc2, configuration);
-        } catch (const std::exception& ex) {
-            std::cerr << "Failed to construct equivalence checking manager: " << ex.what() << std::endl;
-            return {};
-        }
-    }
+  try {
+    return std::make_unique<EquivalenceCheckingManager>(qc1, qc2,
+                                                        configuration);
+  } catch (const std::exception& ex) {
+    std::cerr << "Failed to construct equivalence checking manager: "
+              << ex.what() << std::endl;
+    return {};
+  }
+}
 
-    std::unique_ptr<EquivalenceCheckingManager> createManagerFromOptions(const py::object& circ1, const py::object& circ2,
-                                                                         // Execution
-                                                                         dd::fp               numericalTolerance     = dd::ComplexTable<>::tolerance(),
-                                                                         bool                 parallel               = true,
-                                                                         std::size_t          nthreads               = std::max(2U, std::thread::hardware_concurrency()),
-                                                                         std::chrono::seconds timeout                = 0s,
-                                                                         bool                 runConstructionChecker = false,
-                                                                         bool                 runSimulationChecker   = true,
-                                                                         bool                 runAlternatingChecker  = true,
-                                                                         bool                 runZXChecker           = true,
-                                                                         // Optimization
-                                                                         bool fixOutputPermutationMismatch     = false,
-                                                                         bool fuseSingleQubitGates             = true,
-                                                                         bool reconstructSWAPs                 = true,
-                                                                         bool removeDiagonalGatesBeforeMeasure = false,
-                                                                         bool transformDynamicCircuit          = false,
-                                                                         bool reorderOperations                = true,
-                                                                         // Application
-                                                                         const ApplicationSchemeType& constructionScheme = ApplicationSchemeType::Proportional,
-                                                                         const ApplicationSchemeType& simulationScheme   = ApplicationSchemeType::Proportional,
-                                                                         const ApplicationSchemeType& alternatingScheme  = ApplicationSchemeType::Proportional,
-                                                                         const std::string&           profile            = {},
-                                                                         // Functionality
-                                                                         double traceThreshold = 1e-8,
-                                                                         // Simulation
-                                                                         double           fidelityThreshold = 1e-8,
-                                                                         std::size_t      maxSims           = std::max(16U, std::thread::hardware_concurrency() - 2U),
-                                                                         const StateType& stateType         = StateType::ComputationalBasis,
-                                                                         std::size_t      seed              = 0U,
-                                                                         bool             storeCEXinput     = false,
-                                                                         bool             storeCEXoutput    = false) {
-        Configuration configuration{};
-        // Execution
-        configuration.execution.numericalTolerance     = numericalTolerance;
-        configuration.execution.parallel               = parallel;
-        configuration.execution.nthreads               = nthreads;
-        configuration.execution.timeout                = timeout;
-        configuration.execution.runConstructionChecker = runConstructionChecker;
-        configuration.execution.runSimulationChecker   = runSimulationChecker;
-        configuration.execution.runAlternatingChecker  = runAlternatingChecker;
-        configuration.execution.runZXChecker           = runZXChecker;
-        // Optimization
-        configuration.optimizations.fixOutputPermutationMismatch     = fixOutputPermutationMismatch;
-        configuration.optimizations.fuseSingleQubitGates             = fuseSingleQubitGates;
-        configuration.optimizations.reconstructSWAPs                 = reconstructSWAPs;
-        configuration.optimizations.removeDiagonalGatesBeforeMeasure = removeDiagonalGatesBeforeMeasure;
-        configuration.optimizations.transformDynamicCircuit          = transformDynamicCircuit;
-        configuration.optimizations.reorderOperations                = reorderOperations;
-        // Application
-        configuration.application.profile            = profile;
-        configuration.application.constructionScheme = constructionScheme;
-        if (configuration.application.constructionScheme == ApplicationSchemeType::Lookahead) {
-            throw std::invalid_argument("Lookahead application scheme must not be used with construction checker.");
-        }
-        configuration.application.simulationScheme = simulationScheme;
-        if (configuration.application.simulationScheme == ApplicationSchemeType::Lookahead) {
-            throw std::invalid_argument("Lookahead application scheme must not be used with simulation checker.");
-        }
-        configuration.application.alternatingScheme = alternatingScheme;
-        // Functionality
-        configuration.functionality.traceThreshold = traceThreshold;
-        // Simulation
-        configuration.simulation.fidelityThreshold = fidelityThreshold;
-        configuration.simulation.maxSims           = maxSims;
-        configuration.simulation.stateType         = stateType;
-        configuration.simulation.seed              = seed;
-        configuration.simulation.storeCEXinput     = storeCEXinput;
-        configuration.simulation.storeCEXoutput    = storeCEXoutput;
+std::unique_ptr<EquivalenceCheckingManager> createManagerFromOptions(
+    const py::object& circ1, const py::object& circ2,
+    // Execution
+    dd::fp      numericalTolerance = dd::ComplexTable<>::tolerance(),
+    bool        parallel           = true,
+    std::size_t nthreads = std::max(2U, std::thread::hardware_concurrency()),
+    std::chrono::seconds timeout = 0s, bool runConstructionChecker = false,
+    bool runSimulationChecker = true, bool runAlternatingChecker = true,
+    bool runZXChecker = true,
+    // Optimization
+    bool fixOutputPermutationMismatch = false, bool fuseSingleQubitGates = true,
+    bool reconstructSWAPs = true, bool removeDiagonalGatesBeforeMeasure = false,
+    bool transformDynamicCircuit = false, bool reorderOperations = true,
+    // Application
+    const ApplicationSchemeType& constructionScheme =
+        ApplicationSchemeType::Proportional,
+    const ApplicationSchemeType& simulationScheme =
+        ApplicationSchemeType::Proportional,
+    const ApplicationSchemeType& alternatingScheme =
+        ApplicationSchemeType::Proportional,
+    const std::string& profile = {},
+    // Functionality
+    double traceThreshold = 1e-8,
+    // Simulation
+    double           fidelityThreshold = 1e-8,
+    std::size_t      maxSims           = std::max(16U,
+                                                  std::thread::hardware_concurrency() - 2U),
+    const StateType& stateType         = StateType::ComputationalBasis,
+    std::size_t seed = 0U, bool storeCEXinput = false,
+    bool storeCEXoutput = false) {
+  Configuration configuration{};
+  // Execution
+  configuration.execution.numericalTolerance     = numericalTolerance;
+  configuration.execution.parallel               = parallel;
+  configuration.execution.nthreads               = nthreads;
+  configuration.execution.timeout                = timeout;
+  configuration.execution.runConstructionChecker = runConstructionChecker;
+  configuration.execution.runSimulationChecker   = runSimulationChecker;
+  configuration.execution.runAlternatingChecker  = runAlternatingChecker;
+  configuration.execution.runZXChecker           = runZXChecker;
+  // Optimization
+  configuration.optimizations.fixOutputPermutationMismatch =
+      fixOutputPermutationMismatch;
+  configuration.optimizations.fuseSingleQubitGates = fuseSingleQubitGates;
+  configuration.optimizations.reconstructSWAPs     = reconstructSWAPs;
+  configuration.optimizations.removeDiagonalGatesBeforeMeasure =
+      removeDiagonalGatesBeforeMeasure;
+  configuration.optimizations.transformDynamicCircuit = transformDynamicCircuit;
+  configuration.optimizations.reorderOperations       = reorderOperations;
+  // Application
+  configuration.application.profile            = profile;
+  configuration.application.constructionScheme = constructionScheme;
+  if (configuration.application.constructionScheme ==
+      ApplicationSchemeType::Lookahead) {
+    throw std::invalid_argument("Lookahead application scheme must not be used "
+                                "with construction checker.");
+  }
+  configuration.application.simulationScheme = simulationScheme;
+  if (configuration.application.simulationScheme ==
+      ApplicationSchemeType::Lookahead) {
+    throw std::invalid_argument("Lookahead application scheme must not be used "
+                                "with simulation checker.");
+  }
+  configuration.application.alternatingScheme = alternatingScheme;
+  // Functionality
+  configuration.functionality.traceThreshold = traceThreshold;
+  // Simulation
+  configuration.simulation.fidelityThreshold = fidelityThreshold;
+  configuration.simulation.maxSims           = maxSims;
+  configuration.simulation.stateType         = stateType;
+  configuration.simulation.seed              = seed;
+  configuration.simulation.storeCEXinput     = storeCEXinput;
+  configuration.simulation.storeCEXoutput    = storeCEXoutput;
 
-        return createManagerFromConfiguration(circ1, circ2, configuration);
-    }
+  return createManagerFromConfiguration(circ1, circ2, configuration);
+}
 
-    ec::EquivalenceCheckingManager::Results verify(const py::object& circ1, const py::object& circ2, const Configuration& configuration = Configuration()) {
-        auto ecm = createManagerFromConfiguration(circ1, circ2, configuration);
-        ecm->run();
-        return ecm->getResults();
-    }
+ec::EquivalenceCheckingManager::Results
+verify(const py::object& circ1, const py::object& circ2,
+       const Configuration& configuration = Configuration()) {
+  auto ecm = createManagerFromConfiguration(circ1, circ2, configuration);
+  ecm->run();
+  return ecm->getResults();
+}
 
-    PYBIND11_MODULE(pyqcec, m) {
-        m.doc() = "Python interface for the MQT QCEC quantum circuit equivalence checking tool";
+PYBIND11_MODULE(pyqcec, m) {
+  m.doc() = "Python interface for the MQT QCEC quantum circuit equivalence "
+            "checking tool";
 
-        py::enum_<ApplicationSchemeType>(m, "ApplicationScheme")
-            .value("sequential", ApplicationSchemeType::Sequential,
-                   "Applies all gates from the first circuit, before proceeding with the second circuit. Referred to as *reference* in :cite:p:`burgholzer2021advanced`.")
-            .value("one_to_one", ApplicationSchemeType::OneToOne,
-                   "Alternates between applications from the first and the second circuit. Referred to as *naive* in :cite:p:`burgholzer2021advanced`.")
-            .value("proportional", ApplicationSchemeType::Proportional,
-                   "For every gate of the first circuit, proportionally many are applied from the second circuit according to the difference in the number of gates.")
-            .value("lookahead", ApplicationSchemeType::Lookahead,
-                   "Looks whether an application from the first circuit or the second circuit yields the smaller decision diagram. Only works for the :ref:`alternating checker <EquivalenceChecking:Alternating Equivalence Checker (using Decision Diagrams)>`.")
-            .value("gate_cost", ApplicationSchemeType::GateCost,
-                   "Each gate of the first circuit is associated with a corresponding cost according to some cost function *f(...)*. Whenever a gate *g* from the first circuit is applied *f(g)* gates are applied from the second circuit. Referred to as *compilation_flow* in :cite:p:`burgholzer2020verifyingResultsIBM`.")
-            .def(py::init([](const std::string& str) -> ApplicationSchemeType { return applicationSchemeFromString(str); }))
-            .def(
-                "__str__", [](ApplicationSchemeType scheme) { return toString(scheme); }, py::prepend());
-        py::implicitly_convertible<std::string, ApplicationSchemeType>();
+  py::enum_<ApplicationSchemeType>(m, "ApplicationScheme")
+      .value("sequential", ApplicationSchemeType::Sequential,
+             "Applies all gates from the first circuit, before proceeding with "
+             "the second circuit. Referred to as *reference* in "
+             ":cite:p:`burgholzer2021advanced`.")
+      .value("one_to_one", ApplicationSchemeType::OneToOne,
+             "Alternates between applications from the first and the second "
+             "circuit. Referred to as *naive* in "
+             ":cite:p:`burgholzer2021advanced`.")
+      .value("proportional", ApplicationSchemeType::Proportional,
+             "For every gate of the first circuit, proportionally many are "
+             "applied from the second circuit according to the difference in "
+             "the number of gates.")
+      .value(
+          "lookahead", ApplicationSchemeType::Lookahead,
+          "Looks whether an application from the first circuit or the second "
+          "circuit yields the smaller decision diagram. Only works for the "
+          ":ref:`alternating checker <EquivalenceChecking:Alternating "
+          "Equivalence Checker (using Decision Diagrams)>`.")
+      .value(
+          "gate_cost", ApplicationSchemeType::GateCost,
+          "Each gate of the first circuit is associated with a corresponding "
+          "cost according to some cost function *f(...)*. Whenever a gate *g* "
+          "from the first circuit is applied *f(g)* gates are applied from the "
+          "second circuit. Referred to as *compilation_flow* in "
+          ":cite:p:`burgholzer2020verifyingResultsIBM`.")
+      .def(py::init([](const std::string& str) -> ApplicationSchemeType {
+        return applicationSchemeFromString(str);
+      }))
+      .def(
+          "__str__",
+          [](ApplicationSchemeType scheme) { return toString(scheme); },
+          py::prepend());
+  py::implicitly_convertible<std::string, ApplicationSchemeType>();
 
-        py::enum_<StateType>(m, "StateType")
-            .value("computational_basis", StateType::ComputationalBasis,
-                   "Randomly choose computational basis states. Also referred to as *classical*.")
-            .value("random_1Q_basis", StateType::Random1QBasis,
-                   "Randomly choose a single-qubit basis state for each qubit from the six-tuple *(|0>, |1>, |+>, |->, |L>, |R>)*. Also referred to as *local_random*.")
-            .value("stabilizer", StateType::Stabilizer,
-                   "Randomly choose a stabilizer state by creating a random Clifford circuit. Also referred to as *global_random*.")
-            .def(py::init([](const std::string& str) -> StateType { return stateTypeFromString(str); }))
-            .def(
-                "__str__", [](StateType type) { return toString(type); }, py::prepend());
-        py::implicitly_convertible<std::string, StateType>();
+  py::enum_<StateType>(m, "StateType")
+      .value("computational_basis", StateType::ComputationalBasis,
+             "Randomly choose computational basis states. Also referred to as "
+             "*classical*.")
+      .value("random_1Q_basis", StateType::Random1QBasis,
+             "Randomly choose a single-qubit basis state for each qubit from "
+             "the six-tuple *(|0>, |1>, |+>, |->, |L>, |R>)*. Also referred to "
+             "as *local_random*.")
+      .value("stabilizer", StateType::Stabilizer,
+             "Randomly choose a stabilizer state by creating a random Clifford "
+             "circuit. Also referred to as *global_random*.")
+      .def(py::init([](const std::string& str) -> StateType {
+        return stateTypeFromString(str);
+      }))
+      .def(
+          "__str__", [](StateType type) { return toString(type); },
+          py::prepend());
+  py::implicitly_convertible<std::string, StateType>();
 
-        py::enum_<EquivalenceCriterion>(m, "EquivalenceCriterion")
-            .value("no_information", EquivalenceCriterion::NoInformation,
-                   "No information on the equivalence is available. This can be due to the fact that the check has not been run or that a timeout happened.")
-            .value("not_equivalent", EquivalenceCriterion::NotEquivalent,
-                   "Circuits are shown to be non-equivalent.")
-            .value("equivalent", EquivalenceCriterion::Equivalent,
-                   "Circuits are shown to be equivalent.")
-            .value("equivalent_up_to_phase", EquivalenceCriterion::EquivalentUpToPhase,
-                   "Circuits are equivalent up to a certain (global or relative) phase.")
-            .value("equivalent_up_to_global_phase", EquivalenceCriterion::EquivalentUpToGlobalPhase,
-                   "Circuits are equivalent up to a global phase factor.")
-            .value("probably_equivalent", EquivalenceCriterion::ProbablyEquivalent,
-                   "Circuits are probably equivalent. A result that is obtained whenever a couple of simulations did not show the non-equivalence in the :ref:`simulation checker <EquivalenceChecking:Simulation Equivalence Checker (using Decision Diagrams)>`.")
-            .value("probably_not_equivalent", EquivalenceCriterion::ProbablyNotEquivalent,
-                   "Circuits are probably not equivalent. A result that is obtained whenever the :ref:`ZX-calculus checker <EquivalenceChecking:ZX-Calculus Equivalence Checker>` could not reduce the combined circuit to the identity.")
-            .def(py::init([](const std::string& str) -> EquivalenceCriterion { return fromString(str); }))
-            .def(
-                "__str__", [](EquivalenceCriterion crit) { return toString(crit); }, py::prepend());
-        py::implicitly_convertible<std::string, EquivalenceCriterion>();
+  py::enum_<EquivalenceCriterion>(m, "EquivalenceCriterion")
+      .value("no_information", EquivalenceCriterion::NoInformation,
+             "No information on the equivalence is available. This can be due "
+             "to the fact that the check has not been run or that a timeout "
+             "happened.")
+      .value("not_equivalent", EquivalenceCriterion::NotEquivalent,
+             "Circuits are shown to be non-equivalent.")
+      .value("equivalent", EquivalenceCriterion::Equivalent,
+             "Circuits are shown to be equivalent.")
+      .value(
+          "equivalent_up_to_phase", EquivalenceCriterion::EquivalentUpToPhase,
+          "Circuits are equivalent up to a certain (global or relative) phase.")
+      .value("equivalent_up_to_global_phase",
+             EquivalenceCriterion::EquivalentUpToGlobalPhase,
+             "Circuits are equivalent up to a global phase factor.")
+      .value(
+          "probably_equivalent", EquivalenceCriterion::ProbablyEquivalent,
+          "Circuits are probably equivalent. A result that is obtained "
+          "whenever a couple of simulations did not show the non-equivalence "
+          "in the :ref:`simulation checker <EquivalenceChecking:Simulation "
+          "Equivalence Checker (using Decision Diagrams)>`.")
+      .value("probably_not_equivalent",
+             EquivalenceCriterion::ProbablyNotEquivalent,
+             "Circuits are probably not equivalent. A result that is obtained "
+             "whenever the :ref:`ZX-calculus checker "
+             "<EquivalenceChecking:ZX-Calculus Equivalence Checker>` could not "
+             "reduce the combined circuit to the identity.")
+      .def(py::init([](const std::string& str) -> EquivalenceCriterion {
+        return fromString(str);
+      }))
+      .def(
+          "__str__", [](EquivalenceCriterion crit) { return toString(crit); },
+          py::prepend());
+  py::implicitly_convertible<std::string, EquivalenceCriterion>();
 
-        // Class definitions
-        py::class_<EquivalenceCheckingManager>          ecm(m, "EquivalenceCheckingManager", "Main class for orchestrating the equivalence check");
-        py::class_<EquivalenceCheckingManager::Results> results(ecm, "Results", "Equivalence checking results");
+  // Class definitions
+  py::class_<EquivalenceCheckingManager> ecm(
+      m, "EquivalenceCheckingManager",
+      "Main class for orchestrating the equivalence check");
+  py::class_<EquivalenceCheckingManager::Results> results(
+      ecm, "Results", "Equivalence checking results");
 
-        py::class_<Configuration> configuration(m, "Configuration", "Configuration options for the QCEC quantum circuit equivalence checking tool");
+  py::class_<Configuration> configuration(
+      m, "Configuration",
+      "Configuration options for the QCEC quantum circuit equivalence checking "
+      "tool");
 
-        // Constructors
-        ecm.def(py::init(&createManagerFromOptions), "circ1"_a, "circ2"_a,
-                "numerical_tolerance"_a                  = dd::ComplexTable<>::tolerance(),
-                "parallel"_a                             = true,
-                "nthreads"_a                             = std::max(2U, std::thread::hardware_concurrency()),
-                "timeout"_a                              = 0s,
-                "run_construction_checker"_a             = false,
-                "run_simulation_checker"_a               = true,
-                "run_alternating_checker"_a              = true,
-                "run_zx_checker"_a                       = true,
-                "fix_output_permutation_mismatch"_a      = false,
-                "fuse_single_qubit_gates"_a              = true,
-                "reconstruct_swaps"_a                    = true,
-                "remove_diagonal_gates_before_measure"_a = false,
-                "transform_dynamic_circuit"_a            = false,
-                "reorder_operations"_a                   = true,
-                "construction_scheme"_a                  = "proportional",
-                "simulation_scheme"_a                    = "proportional",
-                "alternating_scheme"_a                   = "proportional",
-                "profile"_a                              = "",
-                "trace_threshold"_a                      = 1e-8,
-                "fidelity_threshold"_a                   = 1e-8,
-                "max_sims"_a                             = std::max(16U, std::thread::hardware_concurrency() - 2U),
-                "state_type"_a                           = "computational_basis",
-                "seed"_a                                 = 0U,
-                "store_cex_input"_a                      = false,
-                "store_cex_output"_a                     = false)
-            .def(py::init([](const py::object& circ1, const py::object& circ2, const Configuration& config) {
-                     return createManagerFromConfiguration(circ1, circ2, config);
-                 }),
-                 "circ1"_a, "circ2"_a, "config"_a)
-            .def("get_configuration", &EquivalenceCheckingManager::getConfiguration)
+  // Constructors
+  ecm.def(
+         py::init(&createManagerFromOptions), "circ1"_a, "circ2"_a,
+         "numerical_tolerance"_a = dd::ComplexTable<>::tolerance(),
+         "parallel"_a            = true,
+         "nthreads"_a = std::max(2U, std::thread::hardware_concurrency()),
+         "timeout"_a = 0s, "run_construction_checker"_a = false,
+         "run_simulation_checker"_a = true, "run_alternating_checker"_a = true,
+         "run_zx_checker"_a = true, "fix_output_permutation_mismatch"_a = false,
+         "fuse_single_qubit_gates"_a = true, "reconstruct_swaps"_a = true,
+         "remove_diagonal_gates_before_measure"_a = false,
+         "transform_dynamic_circuit"_a = false, "reorder_operations"_a = true,
+         "construction_scheme"_a = "proportional",
+         "simulation_scheme"_a   = "proportional",
+         "alternating_scheme"_a = "proportional", "profile"_a = "",
+         "trace_threshold"_a = 1e-8, "fidelity_threshold"_a = 1e-8,
+         "max_sims"_a = std::max(16U, std::thread::hardware_concurrency() - 2U),
+         "state_type"_a = "computational_basis", "seed"_a = 0U,
+         "store_cex_input"_a = false, "store_cex_output"_a = false)
+      .def(py::init([](const py::object& circ1, const py::object& circ2,
+                       const Configuration& config) {
+             return createManagerFromConfiguration(circ1, circ2, config);
+           }),
+           "circ1"_a, "circ2"_a, "config"_a)
+      .def("get_configuration", &EquivalenceCheckingManager::getConfiguration)
 
-            // Convenience functions
-            // Execution
-            .def("set_tolerance", &EquivalenceCheckingManager::setTolerance, "tolerance"_a = dd::ComplexTable<>::tolerance(),
-                 "Set the :attr:`numerical tolerance <.Configuration.Execution.numerical_tolerance>` of the underlying decision diagram package.")
-            .def("set_parallel", &EquivalenceCheckingManager::setParallel, "enable"_a = true,
-                 "Set whether execution should happen in :attr:`~Configuration.Execution.parallel`.")
-            .def("set_nthreads", &EquivalenceCheckingManager::setNThreads, "nthreads"_a = std::max(2U, std::thread::hardware_concurrency()),
-                 "Set the maximum number of :attr:`threads <.Configuration.Execution.nthreads>` to use.")
-            .def("set_timeout", &EquivalenceCheckingManager::setTimeout, "timeout"_a = 0.0,
-                 "Set a :attr:`timeout <.Configuration.Execution.timeout>` (in seconds) for :func:`~EquivalenceCheckingManager.run`. The timeout can also be specified by a :class:`float`.")
-            .def("set_construction_checker", &EquivalenceCheckingManager::setConstructionChecker, "enable"_a = false,
-                 "Set whether the :ref:`construction checker <EquivalenceChecking:Construction Equivalence Checker (using Decision Diagrams)>` should be executed.")
-            .def("set_simulation_checker", &EquivalenceCheckingManager::setSimulationChecker, "enable"_a = true,
-                 "Set whether the :ref:`simulation checker <EquivalenceChecking:Simulation Equivalence Checker (using Decision Diagrams)>` should be executed.")
-            .def("set_alternating_checker", &EquivalenceCheckingManager::setAlternatingChecker, "enable"_a = true,
-                 "Set whether the :ref:`alternating checker <EquivalenceChecking:Alternating Equivalence Checker (using Decision Diagrams)>` should be executed.")
-            .def("set_zx_checker", &EquivalenceCheckingManager::setZXChecker, "enable"_a = true,
-                 "Set whether the :ref:`ZX-calculus checker <EquivalenceChecking:ZX-Calculus Equivalence Checker>` should be executed.")
-            // Optimization
-            .def("fix_output_permutation_mismatch", &EquivalenceCheckingManager::runFixOutputPermutationMismatch,
-                 "Try to :attr:`fix potential mismatches in output permutations <.Configuration.Optimizations.fix_output_permutation_mismatch>`. This is experimental.")
-            .def("fuse_single_qubit_gates", &EquivalenceCheckingManager::fuseSingleQubitGates,
-                 ":attr:`Fuse consecutive single qubit gates <.Configuration.Optimizations.fuse_single_qubit_gates>`.")
-            .def("reconstruct_swaps", &EquivalenceCheckingManager::reconstructSWAPs,
-                 ":attr:`Try to reconstruct SWAP gates <.Configuration.Optimizations.reconstruct_swaps>` that have been decomposed or optimized away.")
-            .def("reorder_operations", &EquivalenceCheckingManager::reorderOperations,
-                 ":attr:`Reorder operations <.Configuration.Optimizations.reorder_operations>` to establish canonical ordering.")
-            // Application
-            .def("set_application_scheme", &EquivalenceCheckingManager::setApplicationScheme, "scheme"_a = "proportional",
-                 "Set the :class:`Application Scheme <.ApplicationScheme>` that is used for all checkers (based on decision diagrams).")
-            .def("set_construction_application_scheme", &EquivalenceCheckingManager::setConstructionApplicationScheme, "scheme"_a = "proportional",
-                 "Set the :class:`Application Scheme <.ApplicationScheme>` that is used for the :ref:`construction checker <EquivalenceChecking:Construction Equivalence Checker (using Decision Diagrams)>`.")
-            .def("set_simulation_application_scheme", &EquivalenceCheckingManager::setSimulationApplicationScheme, "scheme"_a = "proportional",
-                 "Set the :class:`Application Scheme <.ApplicationScheme>` that is used for the :ref:`simulation checker <EquivalenceChecking:Simulation Equivalence Checker (using Decision Diagrams)>`.")
-            .def("set_alternating_application_scheme", &EquivalenceCheckingManager::setAlternatingApplicationScheme, "scheme"_a = "proportional",
-                 "Set the :class:`Application Scheme <.ApplicationScheme>` that is used for the :ref:`alternating checker <EquivalenceChecking:Alternating Equivalence Checker (using Decision Diagrams)>`.")
-            .def("set_gate_cost_profile", &EquivalenceCheckingManager::setGateCostProfile, "profile"_a = "",
-                 "Set the :attr:`profile <.Configuration.Application.profile>` used in the :attr:`Gate Cost <.ApplicationScheme.gate_cost>` application scheme for all checkers (based on decision diagrams).")
-            .def("set_construction_gate_cost_profile", &EquivalenceCheckingManager::setConstructionGateCostProfile, "profile"_a = "",
-                 "Set the :attr:`profile <.Configuration.Application.profile>` used in the :attr:`Gate Cost <.ApplicationScheme.gate_cost>` application scheme for the :ref:`construction checker <EquivalenceChecking:Construction Equivalence Checker (using Decision Diagrams)>`.")
-            .def("set_simulation_gate_cost_profile", &EquivalenceCheckingManager::setSimulationGateCostProfile, "profile"_a = "",
-                 "Set the :attr:`profile <.Configuration.Application.profile>` used in the :attr:`Gate Cost <.ApplicationScheme.gate_cost>` application scheme for the :ref:`simulation checker <EquivalenceChecking:Simulation Equivalence Checker (using Decision Diagrams)>`.")
-            .def("set_alternating_gate_cost_profile", &EquivalenceCheckingManager::setAlternatingGateCostProfile, "profile"_a = "",
-                 "Set the :attr:`profile <.Configuration.Application.profile>` used in the :attr:`Gate Cost <.ApplicationScheme.gate_cost>` application scheme for the :ref:`alternating checker <EquivalenceChecking:Alternating Equivalence Checker (using Decision Diagrams)>`.")
-            // Functionality
-            .def("set_trace_threshold", &EquivalenceCheckingManager::setTraceThreshold, "threshold"_a = 1e-8,
-                 "Set the :attr:`trace threshold <.Configuration.Functionality.trace_threshold>` used for comparing two unitaries or functionality matrices.")
-            // Simulation
-            .def("set_fidelity_threshold", &EquivalenceCheckingManager::setFidelityThreshold, "threshold"_a = 1e-8,
-                 "Set the :attr:`fidelity threshold <.Configuration.Simulation.fidelity_threshold>` used for comparing two states or state vectors.")
-            .def("set_max_sims", &EquivalenceCheckingManager::setMaxSims, "sims"_a = std::max(16U, std::thread::hardware_concurrency() - 2U),
-                 "Set the :attr:`maximum number of simulations <.Configuration.Simulation.max_sims>` to be started for the :ref:`simulation checker <EquivalenceChecking:Simulation Equivalence Checker (using Decision Diagrams)>`.")
-            .def("set_state_type", &EquivalenceCheckingManager::setStateType, "type"_a = "computational_basis",
-                 "Set the :attr:`type of states <.Configuration.Simulation.state_type>` used for the simulations in the :ref:`simulation checker <EquivalenceChecking:Simulation Equivalence Checker (using Decision Diagrams)>`.")
-            .def("set_seed", &EquivalenceCheckingManager::setSeed, "seed"_a = 0U,
-                 "Set the :attr:`seed <.Configuration.Simulation.seed>` for the state generator in the :ref:`simulation checker <EquivalenceChecking:Simulation Equivalence Checker (using Decision Diagrams)>`.")
-            .def("store_cex_input", &EquivalenceCheckingManager::storeCEXinput, "enable"_a = false,
-                 "Set whether to :attr:`store the input state <.Configuration.Simulation.store_cex_input>` if a counterexample is obtained.")
-            .def("store_cex_output", &EquivalenceCheckingManager::storeCEXoutput, "enable"_a = false,
-                 "Set whether to :attr:`store the output states <.Configuration.Simulation.store_cex_input>` if a counterexample is obtained.")
+      // Convenience functions
+      // Execution
+      .def("set_tolerance", &EquivalenceCheckingManager::setTolerance,
+           "tolerance"_a = dd::ComplexTable<>::tolerance(),
+           "Set the :attr:`numerical tolerance "
+           "<.Configuration.Execution.numerical_tolerance>` of the underlying "
+           "decision diagram package.")
+      .def("set_parallel", &EquivalenceCheckingManager::setParallel,
+           "enable"_a = true,
+           "Set whether execution should happen in "
+           ":attr:`~Configuration.Execution.parallel`.")
+      .def("set_nthreads", &EquivalenceCheckingManager::setNThreads,
+           "nthreads"_a = std::max(2U, std::thread::hardware_concurrency()),
+           "Set the maximum number of :attr:`threads "
+           "<.Configuration.Execution.nthreads>` to use.")
+      .def("set_timeout", &EquivalenceCheckingManager::setTimeout,
+           "timeout"_a = 0.0,
+           "Set a :attr:`timeout <.Configuration.Execution.timeout>` (in "
+           "seconds) for :func:`~EquivalenceCheckingManager.run`. The timeout "
+           "can also be specified by a :class:`float`.")
+      .def("set_construction_checker",
+           &EquivalenceCheckingManager::setConstructionChecker,
+           "enable"_a = false,
+           "Set whether the :ref:`construction checker "
+           "<EquivalenceChecking:Construction Equivalence Checker (using "
+           "Decision Diagrams)>` should be executed.")
+      .def("set_simulation_checker",
+           &EquivalenceCheckingManager::setSimulationChecker, "enable"_a = true,
+           "Set whether the :ref:`simulation checker "
+           "<EquivalenceChecking:Simulation Equivalence Checker (using "
+           "Decision Diagrams)>` should be executed.")
+      .def("set_alternating_checker",
+           &EquivalenceCheckingManager::setAlternatingChecker,
+           "enable"_a = true,
+           "Set whether the :ref:`alternating checker "
+           "<EquivalenceChecking:Alternating Equivalence Checker (using "
+           "Decision Diagrams)>` should be executed.")
+      .def("set_zx_checker", &EquivalenceCheckingManager::setZXChecker,
+           "enable"_a = true,
+           "Set whether the :ref:`ZX-calculus checker "
+           "<EquivalenceChecking:ZX-Calculus Equivalence Checker>` should be "
+           "executed.")
+      // Optimization
+      .def("fix_output_permutation_mismatch",
+           &EquivalenceCheckingManager::runFixOutputPermutationMismatch,
+           "Try to :attr:`fix potential mismatches in output permutations "
+           "<.Configuration.Optimizations.fix_output_permutation_mismatch>`. "
+           "This is experimental.")
+      .def("fuse_single_qubit_gates",
+           &EquivalenceCheckingManager::fuseSingleQubitGates,
+           ":attr:`Fuse consecutive single qubit gates "
+           "<.Configuration.Optimizations.fuse_single_qubit_gates>`.")
+      .def("reconstruct_swaps", &EquivalenceCheckingManager::reconstructSWAPs,
+           ":attr:`Try to reconstruct SWAP gates "
+           "<.Configuration.Optimizations.reconstruct_swaps>` that have been "
+           "decomposed or optimized away.")
+      .def("reorder_operations", &EquivalenceCheckingManager::reorderOperations,
+           ":attr:`Reorder operations "
+           "<.Configuration.Optimizations.reorder_operations>` to establish "
+           "canonical ordering.")
+      // Application
+      .def("set_application_scheme",
+           &EquivalenceCheckingManager::setApplicationScheme,
+           "scheme"_a = "proportional",
+           "Set the :class:`Application Scheme <.ApplicationScheme>` that is "
+           "used for all checkers (based on decision diagrams).")
+      .def("set_construction_application_scheme",
+           &EquivalenceCheckingManager::setConstructionApplicationScheme,
+           "scheme"_a = "proportional",
+           "Set the :class:`Application Scheme <.ApplicationScheme>` that is "
+           "used for the :ref:`construction checker "
+           "<EquivalenceChecking:Construction Equivalence Checker (using "
+           "Decision Diagrams)>`.")
+      .def("set_simulation_application_scheme",
+           &EquivalenceCheckingManager::setSimulationApplicationScheme,
+           "scheme"_a = "proportional",
+           "Set the :class:`Application Scheme <.ApplicationScheme>` that is "
+           "used for the :ref:`simulation checker "
+           "<EquivalenceChecking:Simulation Equivalence Checker (using "
+           "Decision Diagrams)>`.")
+      .def("set_alternating_application_scheme",
+           &EquivalenceCheckingManager::setAlternatingApplicationScheme,
+           "scheme"_a = "proportional",
+           "Set the :class:`Application Scheme <.ApplicationScheme>` that is "
+           "used for the :ref:`alternating checker "
+           "<EquivalenceChecking:Alternating Equivalence Checker (using "
+           "Decision Diagrams)>`.")
+      .def("set_gate_cost_profile",
+           &EquivalenceCheckingManager::setGateCostProfile, "profile"_a = "",
+           "Set the :attr:`profile <.Configuration.Application.profile>` used "
+           "in the :attr:`Gate Cost <.ApplicationScheme.gate_cost>` "
+           "application scheme for all checkers (based on decision diagrams).")
+      .def("set_construction_gate_cost_profile",
+           &EquivalenceCheckingManager::setConstructionGateCostProfile,
+           "profile"_a = "",
+           "Set the :attr:`profile <.Configuration.Application.profile>` used "
+           "in the :attr:`Gate Cost <.ApplicationScheme.gate_cost>` "
+           "application scheme for the :ref:`construction checker "
+           "<EquivalenceChecking:Construction Equivalence Checker (using "
+           "Decision Diagrams)>`.")
+      .def("set_simulation_gate_cost_profile",
+           &EquivalenceCheckingManager::setSimulationGateCostProfile,
+           "profile"_a = "",
+           "Set the :attr:`profile <.Configuration.Application.profile>` used "
+           "in the :attr:`Gate Cost <.ApplicationScheme.gate_cost>` "
+           "application scheme for the :ref:`simulation checker "
+           "<EquivalenceChecking:Simulation Equivalence Checker (using "
+           "Decision Diagrams)>`.")
+      .def("set_alternating_gate_cost_profile",
+           &EquivalenceCheckingManager::setAlternatingGateCostProfile,
+           "profile"_a = "",
+           "Set the :attr:`profile <.Configuration.Application.profile>` used "
+           "in the :attr:`Gate Cost <.ApplicationScheme.gate_cost>` "
+           "application scheme for the :ref:`alternating checker "
+           "<EquivalenceChecking:Alternating Equivalence Checker (using "
+           "Decision Diagrams)>`.")
+      // Functionality
+      .def("set_trace_threshold",
+           &EquivalenceCheckingManager::setTraceThreshold, "threshold"_a = 1e-8,
+           "Set the :attr:`trace threshold "
+           "<.Configuration.Functionality.trace_threshold>` used for comparing "
+           "two unitaries or functionality matrices.")
+      // Simulation
+      .def("set_fidelity_threshold",
+           &EquivalenceCheckingManager::setFidelityThreshold,
+           "threshold"_a = 1e-8,
+           "Set the :attr:`fidelity threshold "
+           "<.Configuration.Simulation.fidelity_threshold>` used for comparing "
+           "two states or state vectors.")
+      .def("set_max_sims", &EquivalenceCheckingManager::setMaxSims,
+           "sims"_a = std::max(16U, std::thread::hardware_concurrency() - 2U),
+           "Set the :attr:`maximum number of simulations "
+           "<.Configuration.Simulation.max_sims>` to be started for the "
+           ":ref:`simulation checker <EquivalenceChecking:Simulation "
+           "Equivalence Checker (using Decision Diagrams)>`.")
+      .def("set_state_type", &EquivalenceCheckingManager::setStateType,
+           "type"_a = "computational_basis",
+           "Set the :attr:`type of states "
+           "<.Configuration.Simulation.state_type>` used for the simulations "
+           "in the :ref:`simulation checker <EquivalenceChecking:Simulation "
+           "Equivalence Checker (using Decision Diagrams)>`.")
+      .def("set_seed", &EquivalenceCheckingManager::setSeed, "seed"_a = 0U,
+           "Set the :attr:`seed <.Configuration.Simulation.seed>` for the "
+           "state generator in the :ref:`simulation checker "
+           "<EquivalenceChecking:Simulation Equivalence Checker (using "
+           "Decision Diagrams)>`.")
+      .def("store_cex_input", &EquivalenceCheckingManager::storeCEXinput,
+           "enable"_a = false,
+           "Set whether to :attr:`store the input state "
+           "<.Configuration.Simulation.store_cex_input>` if a counterexample "
+           "is obtained.")
+      .def("store_cex_output", &EquivalenceCheckingManager::storeCEXoutput,
+           "enable"_a = false,
+           "Set whether to :attr:`store the output states "
+           "<.Configuration.Simulation.store_cex_input>` if a counterexample "
+           "is obtained.")
 
-            // Run
-            .def("run", &EquivalenceCheckingManager::run,
-                 "Execute the equivalence check as configured.")
+      // Run
+      .def("run", &EquivalenceCheckingManager::run,
+           "Execute the equivalence check as configured.")
 
-            // Results
-            .def("equivalence", &EquivalenceCheckingManager::equivalence,
-                 "Returns the :class:`.EquivalenceCriterion` that has been determined as the result of the equivalence check.")
-            .def("get_results", &EquivalenceCheckingManager::getResults,
-                 "Returns the :class:`.EquivalenceCheckingManager.Results` of the equivalence check including statistics.")
-            .def("json", &EquivalenceCheckingManager::json,
-                 "Returns a JSON-style dictionary of all the information present in the :class:`.EquivalenceCheckingManager`")
-            .def("__repr__", &EquivalenceCheckingManager::toString,
-                 "Prints a JSON-formatted representation of all the information present in the :class:`.EquivalenceCheckingManager`");
+      // Results
+      .def("equivalence", &EquivalenceCheckingManager::equivalence,
+           "Returns the :class:`.EquivalenceCriterion` that has been "
+           "determined as the result of the equivalence check.")
+      .def("get_results", &EquivalenceCheckingManager::getResults,
+           "Returns the :class:`.EquivalenceCheckingManager.Results` of the "
+           "equivalence check including statistics.")
+      .def("json", &EquivalenceCheckingManager::json,
+           "Returns a JSON-style dictionary of all the information present in "
+           "the :class:`.EquivalenceCheckingManager`")
+      .def("__repr__", &EquivalenceCheckingManager::toString,
+           "Prints a JSON-formatted representation of all the information "
+           "present in the :class:`.EquivalenceCheckingManager`");
 
-        results.def(py::init<>())
-            .def_readwrite("preprocessing_time", &EquivalenceCheckingManager::Results::preprocessingTime,
-                           "Time spent during preprocessing (in seconds).")
-            .def_readwrite("check_time", &EquivalenceCheckingManager::Results::checkTime,
-                           "Time spent during equivalence check (in seconds).")
-            .def_readwrite("equivalence", &EquivalenceCheckingManager::Results::equivalence,
-                           "Final result of the equivalence check.")
-            .def_readwrite("started_simulations", &EquivalenceCheckingManager::Results::startedSimulations,
-                           "Number of simulations that have been started.")
-            .def_readwrite("performed_simulations", &EquivalenceCheckingManager::Results::performedSimulations,
-                           "Number of simulations that have been finished.")
-            .def_readwrite("cex_input", &EquivalenceCheckingManager::Results::cexInput,
-                           "State vector representation of the initial state that produced a counterexample.")
-            .def_readwrite("cex_output1", &EquivalenceCheckingManager::Results::cexOutput1,
-                           "State vector representation of the first circuit's counterexample output state.")
-            .def_readwrite("cex_output2", &EquivalenceCheckingManager::Results::cexOutput2,
-                           "State vector representation of the second circuit's counterexample output state.")
-            .def("considered_equivalent", &EquivalenceCheckingManager::Results::consideredEquivalent,
-                 "Convenience function to check whether the obtained result is to be considered equivalent.")
-            .def("json", &EquivalenceCheckingManager::Results::json,
-                 "Returns a JSON-style dictionary of the results.")
-            .def("__repr__", &EquivalenceCheckingManager::Results::toString,
-                 "Prints a JSON-formatted representation of the results.");
+  results.def(py::init<>())
+      .def_readwrite("preprocessing_time",
+                     &EquivalenceCheckingManager::Results::preprocessingTime,
+                     "Time spent during preprocessing (in seconds).")
+      .def_readwrite("check_time",
+                     &EquivalenceCheckingManager::Results::checkTime,
+                     "Time spent during equivalence check (in seconds).")
+      .def_readwrite("equivalence",
+                     &EquivalenceCheckingManager::Results::equivalence,
+                     "Final result of the equivalence check.")
+      .def_readwrite("started_simulations",
+                     &EquivalenceCheckingManager::Results::startedSimulations,
+                     "Number of simulations that have been started.")
+      .def_readwrite("performed_simulations",
+                     &EquivalenceCheckingManager::Results::performedSimulations,
+                     "Number of simulations that have been finished.")
+      .def_readwrite("cex_input",
+                     &EquivalenceCheckingManager::Results::cexInput,
+                     "State vector representation of the initial state that "
+                     "produced a counterexample.")
+      .def_readwrite("cex_output1",
+                     &EquivalenceCheckingManager::Results::cexOutput1,
+                     "State vector representation of the first circuit's "
+                     "counterexample output state.")
+      .def_readwrite("cex_output2",
+                     &EquivalenceCheckingManager::Results::cexOutput2,
+                     "State vector representation of the second circuit's "
+                     "counterexample output state.")
+      .def("considered_equivalent",
+           &EquivalenceCheckingManager::Results::consideredEquivalent,
+           "Convenience function to check whether the obtained result is to be "
+           "considered equivalent.")
+      .def("json", &EquivalenceCheckingManager::Results::json,
+           "Returns a JSON-style dictionary of the results.")
+      .def("__repr__", &EquivalenceCheckingManager::Results::toString,
+           "Prints a JSON-formatted representation of the results.");
 
-        py::class_<Configuration::Execution>     execution(configuration, "Execution", "Options that orchestrate the :meth:`~.EquivalenceCheckingManager.run` method.");
-        py::class_<Configuration::Optimizations> optimizations(configuration, "Optimizations", "Options that influence which circuit optimizations are applied during pre-processing.");
-        py::class_<Configuration::Application>   application(configuration, "Application", "Options that describe the :class:`Application Scheme <.ApplicationScheme>` that is used for the individual equivalence checkers.");
-        py::class_<Configuration::Functionality> functionality(configuration, "Functionality", "Options for all checkers that consider the whole functionality of a circuit.");
-        py::class_<Configuration::Simulation>    simulation(configuration, "Simulation", "Options that influence the :ref:`simulation checker <EquivalenceChecking:Simulation Equivalence Checker (using Decision Diagrams)>`.");
+  py::class_<Configuration::Execution> execution(
+      configuration, "Execution",
+      "Options that orchestrate the :meth:`~.EquivalenceCheckingManager.run` "
+      "method.");
+  py::class_<Configuration::Optimizations> optimizations(
+      configuration, "Optimizations",
+      "Options that influence which circuit optimizations are applied during "
+      "pre-processing.");
+  py::class_<Configuration::Application> application(
+      configuration, "Application",
+      "Options that describe the :class:`Application Scheme "
+      "<.ApplicationScheme>` that is used for the individual equivalence "
+      "checkers.");
+  py::class_<Configuration::Functionality> functionality(
+      configuration, "Functionality",
+      "Options for all checkers that consider the whole functionality of a "
+      "circuit.");
+  py::class_<Configuration::Simulation> simulation(
+      configuration, "Simulation",
+      "Options that influence the :ref:`simulation checker "
+      "<EquivalenceChecking:Simulation Equivalence Checker (using Decision "
+      "Diagrams)>`.");
 
-        // Configuration
-        configuration.def(py::init<>())
-            .def_readwrite("execution", &Configuration::execution)
-            .def_readwrite("optimizations", &Configuration::optimizations)
-            .def_readwrite("application", &Configuration::application)
-            .def_readwrite("functionality", &Configuration::functionality)
-            .def_readwrite("simulation", &Configuration::simulation)
-            .def("json", &Configuration::json, "Returns a JSON-style dictionary of the configuration.")
-            .def("__repr__", &Configuration::toString, "Prints a JSON-formatted representation of the configuration.");
+  // Configuration
+  configuration.def(py::init<>())
+      .def_readwrite("execution", &Configuration::execution)
+      .def_readwrite("optimizations", &Configuration::optimizations)
+      .def_readwrite("application", &Configuration::application)
+      .def_readwrite("functionality", &Configuration::functionality)
+      .def_readwrite("simulation", &Configuration::simulation)
+      .def("json", &Configuration::json,
+           "Returns a JSON-style dictionary of the configuration.")
+      .def("__repr__", &Configuration::toString,
+           "Prints a JSON-formatted representation of the configuration.");
 
-        execution.def(py::init<>())
-            .def_readwrite("parallel", &Configuration::Execution::parallel, "Set whether execution should happen in parallel. Defaults to :code:`True`.")
-            .def_readwrite("nthreads", &Configuration::Execution::nthreads, "Set the maximum number of threads to use. Defaults to the maximum number of available threads reported by the OS.")
-            .def_readwrite("timeout", &Configuration::Execution::timeout, "Set a timeout for :meth:`~.EquivalenceCheckingManager.run` (in seconds). Either a :class:`datetime.timedelta` or :class:`float`. Defaults to :code:`0.`, which means no timeout.")
-            .def_readwrite("run_construction_checker", &Configuration::Execution::runConstructionChecker, "Set whether the :ref:`construction checker <EquivalenceChecking:Construction Equivalence Checker (using Decision Diagrams)>` should be executed. Defaults to :code:`False` since the :ref:`alternating checker <EquivalenceChecking:Alternating Equivalence Checker (using Decision Diagrams)>` is to be preferred in most cases.")
-            .def_readwrite("run_simulation_checker", &Configuration::Execution::runSimulationChecker, "Set whether the :ref:`simulation checker <EquivalenceChecking:Simulation Equivalence Checker (using Decision Diagrams)>` should be executed. Defaults to :code:`True` since simulations can quickly show the non-equivalence of circuits in many cases.")
-            .def_readwrite("run_alternating_checker", &Configuration::Execution::runAlternatingChecker, "Set whether the :ref:`alternating checker <EquivalenceChecking:Alternating Equivalence Checker (using Decision Diagrams)>` should be executed. Defaults to :code:`True` since staying close to the identity can quickly show the equivalence of circuits in many cases.")
-            .def_readwrite("run_zx_checker", &Configuration::Execution::runZXChecker, "Set whether the :ref:`ZX-calculus checker <EquivalenceChecking:ZX-Calculus Equivalence Checker>` should be executed. Defaults to :code:`True` but arbitrary multi-controlled operations are only partially supported.")
-            .def_readwrite("numerical_tolerance", &Configuration::Execution::numericalTolerance, "Set the numerical tolerance of the underlying decision diagram package. Defaults to :code:`~2e-13` and should only be changed by users who know what they are doing.");
+  execution.def(py::init<>())
+      .def_readwrite("parallel", &Configuration::Execution::parallel,
+                     "Set whether execution should happen in parallel. "
+                     "Defaults to :code:`True`.")
+      .def_readwrite(
+          "nthreads", &Configuration::Execution::nthreads,
+          "Set the maximum number of threads to use. Defaults to the maximum "
+          "number of available threads reported by the OS.")
+      .def_readwrite(
+          "timeout", &Configuration::Execution::timeout,
+          "Set a timeout for :meth:`~.EquivalenceCheckingManager.run` (in "
+          "seconds). Either a :class:`datetime.timedelta` or :class:`float`. "
+          "Defaults to :code:`0.`, which means no timeout.")
+      .def_readwrite(
+          "run_construction_checker",
+          &Configuration::Execution::runConstructionChecker,
+          "Set whether the :ref:`construction checker "
+          "<EquivalenceChecking:Construction Equivalence Checker (using "
+          "Decision Diagrams)>` should be executed. Defaults to :code:`False` "
+          "since the :ref:`alternating checker "
+          "<EquivalenceChecking:Alternating Equivalence Checker (using "
+          "Decision Diagrams)>` is to be preferred in most cases.")
+      .def_readwrite("run_simulation_checker",
+                     &Configuration::Execution::runSimulationChecker,
+                     "Set whether the :ref:`simulation checker "
+                     "<EquivalenceChecking:Simulation Equivalence Checker "
+                     "(using Decision Diagrams)>` should be executed. Defaults "
+                     "to :code:`True` since simulations can quickly show the "
+                     "non-equivalence of circuits in many cases.")
+      .def_readwrite("run_alternating_checker",
+                     &Configuration::Execution::runAlternatingChecker,
+                     "Set whether the :ref:`alternating checker "
+                     "<EquivalenceChecking:Alternating Equivalence Checker "
+                     "(using Decision Diagrams)>` should be executed. Defaults "
+                     "to :code:`True` since staying close to the identity can "
+                     "quickly show the equivalence of circuits in many cases.")
+      .def_readwrite(
+          "run_zx_checker", &Configuration::Execution::runZXChecker,
+          "Set whether the :ref:`ZX-calculus checker "
+          "<EquivalenceChecking:ZX-Calculus Equivalence Checker>` should be "
+          "executed. Defaults to :code:`True` but arbitrary multi-controlled "
+          "operations are only partially supported.")
+      .def_readwrite("numerical_tolerance",
+                     &Configuration::Execution::numericalTolerance,
+                     "Set the numerical tolerance of the underlying decision "
+                     "diagram package. Defaults to :code:`~2e-13` and should "
+                     "only be changed by users who know what they are doing.");
 
-        optimizations.def(py::init<>())
-            .def_readwrite("fix_output_permutation_mismatch", &Configuration::Optimizations::fixOutputPermutationMismatch, "Try to fix potential mismatches in output permutations. This is experimental and, hence, defaults to :code:`False`.")
-            .def_readwrite("fuse_single_qubit_gates", &Configuration::Optimizations::fuseSingleQubitGates, "Fuse consecutive single-qubit gates by grouping them together. Defaults to :code:`True` as this typically increases the performance of the subsequent equivalence check.")
-            .def_readwrite("reconstruct_swaps", &Configuration::Optimizations::reconstructSWAPs, "Try to reconstruct SWAP gates that have been decomposed (into a sequence of 3 CNOT gates) or optimized away (as a consequence of a SWAP preceded or followed by a CNOT on the same qubits). Defaults to :code:`True` since this reconstruction enables the efficient tracking of logical to physical qubit permutations throughout circuits that have been mapped to a target architecture.")
-            .def_readwrite("remove_diagonal_gates_before_measure", &Configuration::Optimizations::removeDiagonalGatesBeforeMeasure, "Remove any diagonal gates at the end of the circuit. This might be desirable since any diagonal gate in front of a measurement does not influence the probabilities of the respective states. Defaults to :code:`False` since, in general, circuits differing by diagonal gates at the end should still be considered non-equivalent.")
-            .def_readwrite("transform_dynamic_circuit", &Configuration::Optimizations::transformDynamicCircuit, "Circuits containing dynamic circuit primitives such as mid-circuit measurements, resets, or classically-controlled operations cannot be verified in a straight-forward fashion due to the non-unitary nature of these primitives, which is why this setting defaults to :code:`False`. By enabling this optimization, any dynamic circuit is first transformed to a circuit without non-unitary primitives by, first, substituting qubit resets with new qubits and, then, applying the deferred measurement principle to defer measurements to the end.")
-            .def_readwrite("reorder_operations", &Configuration::Optimizations::reorderOperations, "The operations of a circuit are stored in a sequential container. This introduces some dependencies in the order of operations that are not naturally present in the quantum circuit. As a consequence, two quantum circuits that contain exactly the same operations, list their operations in different ways, also apply there operations in a different order. This optimization pass established a canonical ordering of operations by, first, constructing a directed, acyclic graph for the operations and, then, traversing it in a breadth-first fashion. Defaults to :code:`True`.");
+  optimizations.def(py::init<>())
+      .def_readwrite(
+          "fix_output_permutation_mismatch",
+          &Configuration::Optimizations::fixOutputPermutationMismatch,
+          "Try to fix potential mismatches in output permutations. This is "
+          "experimental and, hence, defaults to :code:`False`.")
+      .def_readwrite(
+          "fuse_single_qubit_gates",
+          &Configuration::Optimizations::fuseSingleQubitGates,
+          "Fuse consecutive single-qubit gates by grouping them together. "
+          "Defaults to :code:`True` as this typically increases the "
+          "performance of the subsequent equivalence check.")
+      .def_readwrite(
+          "reconstruct_swaps", &Configuration::Optimizations::reconstructSWAPs,
+          "Try to reconstruct SWAP gates that have been decomposed (into a "
+          "sequence of 3 CNOT gates) or optimized away (as a consequence of a "
+          "SWAP preceded or followed by a CNOT on the same qubits). Defaults "
+          "to :code:`True` since this reconstruction enables the efficient "
+          "tracking of logical to physical qubit permutations throughout "
+          "circuits that have been mapped to a target architecture.")
+      .def_readwrite(
+          "remove_diagonal_gates_before_measure",
+          &Configuration::Optimizations::removeDiagonalGatesBeforeMeasure,
+          "Remove any diagonal gates at the end of the circuit. This might be "
+          "desirable since any diagonal gate in front of a measurement does "
+          "not influence the probabilities of the respective states. Defaults "
+          "to :code:`False` since, in general, circuits differing by diagonal "
+          "gates at the end should still be considered non-equivalent.")
+      .def_readwrite(
+          "transform_dynamic_circuit",
+          &Configuration::Optimizations::transformDynamicCircuit,
+          "Circuits containing dynamic circuit primitives such as mid-circuit "
+          "measurements, resets, or classically-controlled operations cannot "
+          "be verified in a straight-forward fashion due to the non-unitary "
+          "nature of these primitives, which is why this setting defaults to "
+          ":code:`False`. By enabling this optimization, any dynamic circuit "
+          "is first transformed to a circuit without non-unitary primitives "
+          "by, first, substituting qubit resets with new qubits and, then, "
+          "applying the deferred measurement principle to defer measurements "
+          "to the end.")
+      .def_readwrite(
+          "reorder_operations",
+          &Configuration::Optimizations::reorderOperations,
+          "The operations of a circuit are stored in a sequential container. "
+          "This introduces some dependencies in the order of operations that "
+          "are not naturally present in the quantum circuit. As a consequence, "
+          "two quantum circuits that contain exactly the same operations, list "
+          "their operations in different ways, also apply there operations in "
+          "a different order. This optimization pass established a canonical "
+          "ordering of operations by, first, constructing a directed, acyclic "
+          "graph for the operations and, then, traversing it in a "
+          "breadth-first fashion. Defaults to :code:`True`.");
 
-        application.def(py::init<>())
-            .def_readwrite("construction_scheme", &Configuration::Application::constructionScheme, "The :class:`Application Scheme <.ApplicationScheme>` used for the :ref:`construction checker <EquivalenceChecking:Construction Equivalence Checker (using Decision Diagrams)>`.")
-            .def_readwrite("simulation_scheme", &Configuration::Application::simulationScheme, "The :class:`Application Scheme <.ApplicationScheme>` used for the :ref:`simulation checker <EquivalenceChecking:Simulation Equivalence Checker (using Decision Diagrams)>`.")
-            .def_readwrite("alternating_scheme", &Configuration::Application::alternatingScheme, "The :class:`Application Scheme <.ApplicationScheme>` used for the :ref:`alternating checker <EquivalenceChecking:Alternating Equivalence Checker (using Decision Diagrams)>`.")
-            .def_readwrite("profile", &Configuration::Application::profile, "The :attr:`Gate Cost <.ApplicationScheme.gate_cost>` application scheme can be configured with a profile that specifies the cost of gates. At the moment, this profile can be set via a file that is constructed similar to a lookup table. Every line :code:`<GATE_ID> <N_CONTROLS> <COST>` specified the cost for a given gate type and with a certain number of controls, e.g., :code:`X 0 1` denotes that a single-qubit X gate has a cost of :code:`1`, while :code:`X 2 15` denotes that a Toffoli gate has a cost of :code:`15`.");
+  application.def(py::init<>())
+      .def_readwrite(
+          "construction_scheme",
+          &Configuration::Application::constructionScheme,
+          "The :class:`Application Scheme <.ApplicationScheme>` used for the "
+          ":ref:`construction checker <EquivalenceChecking:Construction "
+          "Equivalence Checker (using Decision Diagrams)>`.")
+      .def_readwrite(
+          "simulation_scheme", &Configuration::Application::simulationScheme,
+          "The :class:`Application Scheme <.ApplicationScheme>` used for the "
+          ":ref:`simulation checker <EquivalenceChecking:Simulation "
+          "Equivalence Checker (using Decision Diagrams)>`.")
+      .def_readwrite(
+          "alternating_scheme", &Configuration::Application::alternatingScheme,
+          "The :class:`Application Scheme <.ApplicationScheme>` used for the "
+          ":ref:`alternating checker <EquivalenceChecking:Alternating "
+          "Equivalence Checker (using Decision Diagrams)>`.")
+      .def_readwrite(
+          "profile", &Configuration::Application::profile,
+          "The :attr:`Gate Cost <.ApplicationScheme.gate_cost>` application "
+          "scheme can be configured with a profile that specifies the cost of "
+          "gates. At the moment, this profile can be set via a file that is "
+          "constructed similar to a lookup table. Every line :code:`<GATE_ID> "
+          "<N_CONTROLS> <COST>` specified the cost for a given gate type and "
+          "with a certain number of controls, e.g., :code:`X 0 1` denotes that "
+          "a single-qubit X gate has a cost of :code:`1`, while :code:`X 2 15` "
+          "denotes that a Toffoli gate has a cost of :code:`15`.");
 
-        functionality.def(py::init<>())
-            .def_readwrite("trace_threshold", &Configuration::Functionality::traceThreshold, "While decision diagrams are canonical in theory, i.e., equivalent circuits produce equivalent decision diagrams, numerical inaccuracies and approximations can harm this property. This can result in a scenario where two decision diagrams are really close to one another, but cannot be identified as such by standard methods (i.e., comparing their root pointers). Instead, for two decision diagrams :code:`U` and :code:`U'` representing the functionalities of two circuits :code:`G` and :code:`G'`, the trace of the product of one decision diagram with the inverse of the other can be computed and compared to the trace of the identity. Alternatively, it can be checked, whether :code:`U*U`^-1` is \"close enough\" to the identity by recursively checking that each decision diagram node is close enough to the identity structure (i.e., the first and last successor have weights close to one, while the second and third successor have weights close to zero). Whenever any decision diagram node differs from this structure by more than the configured threshold, the circuits are concluded to be non-equivalent. Defaults to :code:`1e-8`.");
+  functionality.def(py::init<>())
+      .def_readwrite(
+          "trace_threshold", &Configuration::Functionality::traceThreshold,
+          "While decision diagrams are canonical in theory, i.e., equivalent "
+          "circuits produce equivalent decision diagrams, numerical "
+          "inaccuracies and approximations can harm this property. This can "
+          "result in a scenario where two decision diagrams are really close "
+          "to one another, but cannot be identified as such by standard "
+          "methods (i.e., comparing their root pointers). Instead, for two "
+          "decision diagrams :code:`U` and :code:`U'` representing the "
+          "functionalities of two circuits :code:`G` and :code:`G'`, the trace "
+          "of the product of one decision diagram with the inverse of the "
+          "other can be computed and compared to the trace of the identity. "
+          "Alternatively, it can be checked, whether :code:`U*U`^-1` is "
+          "\"close enough\" to the identity by recursively checking that each "
+          "decision diagram node is close enough to the identity structure "
+          "(i.e., the first and last successor have weights close to one, "
+          "while the second and third successor have weights close to zero). "
+          "Whenever any decision diagram node differs from this structure by "
+          "more than the configured threshold, the circuits are concluded to "
+          "be non-equivalent. Defaults to :code:`1e-8`.");
 
-        simulation.def(py::init<>())
-            .def_readwrite("fidelity_threshold", &Configuration::Simulation::fidelityThreshold, "Similar to :attr:`trace threshold <.Configuration.Functionality.trace_threshold>`, this setting is here to tackle numerical inaccuracies and approximations for the :ref:`simulation checker <EquivalenceChecking:Simulation Equivalence Checker (using Decision Diagrams)>`. Instead of computing a trace, the fidelity between the states resulting from the simulation is computed. Whenever the fidelity differs from :code:`1.` by more than the configured threshold, the circuits are concluded to be non-equivalent. Defaults to :code:`1e-8`.")
-            .def_readwrite("max_sims", &Configuration::Simulation::maxSims, "The maximum number of simulations to be started for the :ref:`simulation checker <EquivalenceChecking:Simulation Equivalence Checker (using Decision Diagrams)>`. In practice, just a couple of simulations suffice in most cases to detect a potential non-equivalence. Either defaults to :code:`16` or the maximum number of available threads minus 2, whichever is more.")
-            .def_readwrite("state_type", &Configuration::Simulation::stateType, "The :class:`type of states <.StateType>` used for the simulations in the :ref:`simulation checker <EquivalenceChecking:Simulation Equivalence Checker (using Decision Diagrams)>`.")
-            .def_readwrite("seed", &Configuration::Simulation::seed, "The seed used in the quantum state generator. Defaults to :code:`0`, which means that the seed is chosen non-deterministically for each program run.")
-            .def_readwrite("store_cex_input", &Configuration::Simulation::storeCEXinput, "Whether to store the input state that has lead to the determination of a counterexample. Since the memory required to store a full representation of a quantum state increases exponentially, this is only recommended for a small number of qubits and defaults to :code:`False`.")
-            .def_readwrite("store_cex_output", &Configuration::Simulation::storeCEXoutput, "Whether to store the resulting states that prove the non-equivalence of both circuits. Since the memory required to store a full representation of a quantum state increases exponentially, this is only recommended for a small number of qubits and defaults to :code:`False`.");
+  simulation.def(py::init<>())
+      .def_readwrite(
+          "fidelity_threshold", &Configuration::Simulation::fidelityThreshold,
+          "Similar to :attr:`trace threshold "
+          "<.Configuration.Functionality.trace_threshold>`, this setting is "
+          "here to tackle numerical inaccuracies and approximations for the "
+          ":ref:`simulation checker <EquivalenceChecking:Simulation "
+          "Equivalence Checker (using Decision Diagrams)>`. Instead of "
+          "computing a trace, the fidelity between the states resulting from "
+          "the simulation is computed. Whenever the fidelity differs from "
+          ":code:`1.` by more than the configured threshold, the circuits are "
+          "concluded to be non-equivalent. Defaults to :code:`1e-8`.")
+      .def_readwrite(
+          "max_sims", &Configuration::Simulation::maxSims,
+          "The maximum number of simulations to be started for the "
+          ":ref:`simulation checker <EquivalenceChecking:Simulation "
+          "Equivalence Checker (using Decision Diagrams)>`. In practice, just "
+          "a couple of simulations suffice in most cases to detect a potential "
+          "non-equivalence. Either defaults to :code:`16` or the maximum "
+          "number of available threads minus 2, whichever is more.")
+      .def_readwrite(
+          "state_type", &Configuration::Simulation::stateType,
+          "The :class:`type of states <.StateType>` used for the simulations "
+          "in the :ref:`simulation checker <EquivalenceChecking:Simulation "
+          "Equivalence Checker (using Decision Diagrams)>`.")
+      .def_readwrite("seed", &Configuration::Simulation::seed,
+                     "The seed used in the quantum state generator. Defaults "
+                     "to :code:`0`, which means that the seed is chosen "
+                     "non-deterministically for each program run.")
+      .def_readwrite(
+          "store_cex_input", &Configuration::Simulation::storeCEXinput,
+          "Whether to store the input state that has lead to the determination "
+          "of a counterexample. Since the memory required to store a full "
+          "representation of a quantum state increases exponentially, this is "
+          "only recommended for a small number of qubits and defaults to "
+          ":code:`False`.")
+      .def_readwrite(
+          "store_cex_output", &Configuration::Simulation::storeCEXoutput,
+          "Whether to store the resulting states that prove the "
+          "non-equivalence of both circuits. Since the memory required to "
+          "store a full representation of a quantum state increases "
+          "exponentially, this is only recommended for a small number of "
+          "qubits and defaults to :code:`False`.");
 
-        m.def("verify", &verify,
-              "circ1"_a, "circ2"_a,
-              "config"_a = ec::Configuration{},
-              "Convenience function for verifying the equivalence of two circuits. Wraps creating an instance of :class:`EquivalenceCheckingManager <.EquivalenceCheckingManager>`, calling :meth:`EquivalenceCheckingManager.run` and calling :meth:`EquivalenceCheckingManager.get_result`.");
+  m.def("verify", &verify, "circ1"_a, "circ2"_a,
+        "config"_a = ec::Configuration{},
+        "Convenience function for verifying the equivalence of two circuits. "
+        "Wraps creating an instance of :class:`EquivalenceCheckingManager "
+        "<.EquivalenceCheckingManager>`, calling "
+        ":meth:`EquivalenceCheckingManager.run` and calling "
+        ":meth:`EquivalenceCheckingManager.get_result`.");
 
 #ifdef VERSION_INFO
-        m.attr("__version__") = MACRO_STRINGIFY(VERSION_INFO);
+  m.attr("__version__") = MACRO_STRINGIFY(VERSION_INFO);
 #else
-        m.attr("__version__") = "dev";
+  m.attr("__version__") = "dev";
 #endif
-    }
+}
 } // namespace ec

--- a/src/EquivalenceCheckingManager.cpp
+++ b/src/EquivalenceCheckingManager.cpp
@@ -1,6 +1,6 @@
 //
-// This file is part of MQT QCEC library which is released under the MIT license.
-// See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
 #include "EquivalenceCheckingManager.hpp"
@@ -12,603 +12,670 @@
 #include <memory>
 
 namespace ec {
-    void EquivalenceCheckingManager::setupAncillariesAndGarbage() {
-        auto&          largerCircuit   = qc1.getNqubits() > qc2.getNqubits() ? this->qc1 : this->qc2;
-        auto&          smallerCircuit  = qc1.getNqubits() > qc2.getNqubits() ? this->qc2 : this->qc1;
-        dd::QubitCount qubitDifference = largerCircuit.getNqubits() - smallerCircuit.getNqubits();
+void EquivalenceCheckingManager::setupAncillariesAndGarbage() {
+  auto& largerCircuit =
+      qc1.getNqubits() > qc2.getNqubits() ? this->qc1 : this->qc2;
+  auto& smallerCircuit =
+      qc1.getNqubits() > qc2.getNqubits() ? this->qc2 : this->qc1;
+  dd::QubitCount qubitDifference =
+      largerCircuit.getNqubits() - smallerCircuit.getNqubits();
 
-        std::vector<std::pair<dd::Qubit, dd::Qubit>> removed{};
-        removed.reserve(qubitDifference);
+  std::vector<std::pair<dd::Qubit, dd::Qubit>> removed{};
+  removed.reserve(qubitDifference);
 
-        const auto        nqubits = largerCircuit.getNqubits();
-        std::vector<bool> garbage(nqubits);
+  const auto        nqubits = largerCircuit.getNqubits();
+  std::vector<bool> garbage(nqubits);
 
-        for (dd::QubitCount i = 0; i < qubitDifference; ++i) {
-            auto logicalQubitIndex     = qc::QuantumComputation::getHighestLogicalQubitIndex(largerCircuit.initialLayout);
-            garbage[logicalQubitIndex] = largerCircuit.logicalQubitIsGarbage(logicalQubitIndex);
-            removed.push_back(largerCircuit.removeQubit(logicalQubitIndex));
-        }
+  for (dd::QubitCount i = 0; i < qubitDifference; ++i) {
+    auto logicalQubitIndex =
+        qc::QuantumComputation::getHighestLogicalQubitIndex(
+            largerCircuit.initialLayout);
+    garbage[logicalQubitIndex] =
+        largerCircuit.logicalQubitIsGarbage(logicalQubitIndex);
+    removed.push_back(largerCircuit.removeQubit(logicalQubitIndex));
+  }
 
-        // add appropriate ancillary register to smaller circuit
-        smallerCircuit.addAncillaryRegister(qubitDifference);
+  // add appropriate ancillary register to smaller circuit
+  smallerCircuit.addAncillaryRegister(qubitDifference);
 
-        // reverse iterate over the removed qubits and add them back into the larger circuit as ancillary
-        for (auto it = removed.rbegin(); it != removed.rend(); ++it) {
-            largerCircuit.addAncillaryQubit(it->first, it->second);
-            // restore garbage
-            if (garbage[largerCircuit.getNqubits() - 1]) {
-                largerCircuit.setLogicalQubitGarbage(static_cast<dd::Qubit>(largerCircuit.getNqubits() - 1));
-            }
-            // also set the appropriate qubits in the smaller circuit as garbage
-            smallerCircuit.setLogicalQubitGarbage(static_cast<dd::Qubit>(largerCircuit.getNqubits() - 1));
-        }
+  // reverse iterate over the removed qubits and add them back into the larger
+  // circuit as ancillary
+  for (auto it = removed.rbegin(); it != removed.rend(); ++it) {
+    largerCircuit.addAncillaryQubit(it->first, it->second);
+    // restore garbage
+    if (garbage[largerCircuit.getNqubits() - 1]) {
+      largerCircuit.setLogicalQubitGarbage(
+          static_cast<dd::Qubit>(largerCircuit.getNqubits() - 1));
+    }
+    // also set the appropriate qubits in the smaller circuit as garbage
+    smallerCircuit.setLogicalQubitGarbage(
+        static_cast<dd::Qubit>(largerCircuit.getNqubits() - 1));
+  }
+}
+
+void EquivalenceCheckingManager::fixOutputPermutationMismatch() {
+  // Try to fix potential mismatches in output permutations
+  auto& smallerCircuit = qc1.getNqubits() > qc2.getNqubits() ? qc2 : qc1;
+  auto& largerCircuit  = qc1.getNqubits() > qc2.getNqubits() ? qc1 : qc2;
+
+  auto& smallerGarbage = smallerCircuit.garbage;
+
+  const auto& largerOutput  = largerCircuit.outputPermutation;
+  auto&       largerGarbage = largerCircuit.garbage;
+
+  for (const auto& [lPhysical, lLogical] : largerOutput) {
+    dd::Qubit outputQubitInLargerCircuit = lLogical;
+    dd::Qubit nout                       = 1;
+    for (dd::Qubit i = 0; i < outputQubitInLargerCircuit; ++i) {
+      if (!largerGarbage[i]) {
+        ++nout;
+      }
     }
 
-    void EquivalenceCheckingManager::fixOutputPermutationMismatch() {
-        // Try to fix potential mismatches in output permutations
-        auto& smallerCircuit = qc1.getNqubits() > qc2.getNqubits() ? qc2 : qc1;
-        auto& largerCircuit  = qc1.getNqubits() > qc2.getNqubits() ? qc1 : qc2;
-
-        auto& smallerGarbage = smallerCircuit.garbage;
-
-        const auto& largerOutput  = largerCircuit.outputPermutation;
-        auto&       largerGarbage = largerCircuit.garbage;
-
-        for (const auto& [lPhysical, lLogical]: largerOutput) {
-            dd::Qubit outputQubitInLargerCircuit = lLogical;
-            dd::Qubit nout                       = 1;
-            for (dd::Qubit i = 0; i < outputQubitInLargerCircuit; ++i) {
-                if (!largerGarbage[i]) {
-                    ++nout;
-                }
-            }
-
-            dd::QubitCount outcount        = nout;
-            bool           existsInSmaller = false;
-            for (dd::QubitCount i = 0; i < smallerCircuit.getNqubits(); ++i) {
-                if (!smallerGarbage[i]) {
-                    --outcount;
-                }
-                if (outcount == 0) {
-                    existsInSmaller = true;
-                    break;
-                }
-            }
-            // algorithm has logical qubit that does not exist in the smaller circuit
-            if (!existsInSmaller) {
-                continue;
-            }
-
-            std::cerr << "Uncorrected mismatch in output qubits!" << std::endl;
-        }
+    dd::QubitCount outcount        = nout;
+    bool           existsInSmaller = false;
+    for (dd::QubitCount i = 0; i < smallerCircuit.getNqubits(); ++i) {
+      if (!smallerGarbage[i]) {
+        --outcount;
+      }
+      if (outcount == 0) {
+        existsInSmaller = true;
+        break;
+      }
+    }
+    // algorithm has logical qubit that does not exist in the smaller circuit
+    if (!existsInSmaller) {
+      continue;
     }
 
-    void EquivalenceCheckingManager::runOptimizationPasses() {
-        if (qc1.empty() && qc2.empty()) {
-            return;
-        }
+    std::cerr << "Uncorrected mismatch in output qubits!" << std::endl;
+  }
+}
 
-        const auto isDynamicCircuit1 = qc::CircuitOptimizer::isDynamicCircuit(qc1);
-        const auto isDynamicCircuit2 = qc::CircuitOptimizer::isDynamicCircuit(qc2);
-        if (isDynamicCircuit1 || isDynamicCircuit2) {
-            if (configuration.optimizations.transformDynamicCircuit) {
-                if (isDynamicCircuit1) {
-                    qc::CircuitOptimizer::eliminateResets(qc1);
-                    qc::CircuitOptimizer::deferMeasurements(qc1);
-                }
-                if (isDynamicCircuit2) {
-                    qc::CircuitOptimizer::eliminateResets(qc2);
-                    qc::CircuitOptimizer::deferMeasurements(qc2);
-                }
-            } else {
-                throw std::runtime_error("One of the circuits contains mid-circuit non-unitary primitives. "
-                                         "Configure your instance with `transformDynamicCircuit=true`.");
-            }
-        }
+void EquivalenceCheckingManager::runOptimizationPasses() {
+  if (qc1.empty() && qc2.empty()) {
+    return;
+  }
 
-        if (configuration.optimizations.removeDiagonalGatesBeforeMeasure) {
-            qc::CircuitOptimizer::removeDiagonalGatesBeforeMeasure(qc1);
-            qc::CircuitOptimizer::removeDiagonalGatesBeforeMeasure(qc2);
-        }
+  const auto isDynamicCircuit1 = qc::CircuitOptimizer::isDynamicCircuit(qc1);
+  const auto isDynamicCircuit2 = qc::CircuitOptimizer::isDynamicCircuit(qc2);
+  if (isDynamicCircuit1 || isDynamicCircuit2) {
+    if (configuration.optimizations.transformDynamicCircuit) {
+      if (isDynamicCircuit1) {
+        qc::CircuitOptimizer::eliminateResets(qc1);
+        qc::CircuitOptimizer::deferMeasurements(qc1);
+      }
+      if (isDynamicCircuit2) {
+        qc::CircuitOptimizer::eliminateResets(qc2);
+        qc::CircuitOptimizer::deferMeasurements(qc2);
+      }
+    } else {
+      throw std::runtime_error(
+          "One of the circuits contains mid-circuit non-unitary primitives. "
+          "Configure your instance with `transformDynamicCircuit=true`.");
+    }
+  }
 
-        if (configuration.optimizations.reconstructSWAPs) {
-            qc::CircuitOptimizer::swapReconstruction(qc1);
-            qc::CircuitOptimizer::swapReconstruction(qc2);
-        }
+  if (configuration.optimizations.removeDiagonalGatesBeforeMeasure) {
+    qc::CircuitOptimizer::removeDiagonalGatesBeforeMeasure(qc1);
+    qc::CircuitOptimizer::removeDiagonalGatesBeforeMeasure(qc2);
+  }
 
-        if (configuration.optimizations.fuseSingleQubitGates) {
-            qc::CircuitOptimizer::singleQubitGateFusion(qc1);
-            qc::CircuitOptimizer::singleQubitGateFusion(qc2);
-        }
+  if (configuration.optimizations.reconstructSWAPs) {
+    qc::CircuitOptimizer::swapReconstruction(qc1);
+    qc::CircuitOptimizer::swapReconstruction(qc2);
+  }
 
-        if (configuration.optimizations.reorderOperations) {
-            qc::CircuitOptimizer::reorderOperations(qc1);
-            qc::CircuitOptimizer::reorderOperations(qc2);
-        }
+  if (configuration.optimizations.fuseSingleQubitGates) {
+    qc::CircuitOptimizer::singleQubitGateFusion(qc1);
+    qc::CircuitOptimizer::singleQubitGateFusion(qc2);
+  }
 
-        // remove final measurements from both circuits so that the underlying functionality should be unitary
-        qc::CircuitOptimizer::removeFinalMeasurements(qc1);
-        qc::CircuitOptimizer::removeFinalMeasurements(qc2);
+  if (configuration.optimizations.reorderOperations) {
+    qc::CircuitOptimizer::reorderOperations(qc1);
+    qc::CircuitOptimizer::reorderOperations(qc2);
+  }
+
+  // remove final measurements from both circuits so that the underlying
+  // functionality should be unitary
+  qc::CircuitOptimizer::removeFinalMeasurements(qc1);
+  qc::CircuitOptimizer::removeFinalMeasurements(qc2);
+}
+
+void EquivalenceCheckingManager::run() {
+  done                = false;
+  results.equivalence = EquivalenceCriterion::NoInformation;
+
+  if (!configuration.anythingToExecute()) {
+    std::clog << "Nothing to be executed. Check your configuration!"
+              << std::endl;
+    return;
+  }
+
+  if (!configuration.execution.parallel ||
+      configuration.execution.nthreads <= 1 || configuration.onlySingleTask()) {
+    checkSequential();
+  } else {
+    checkParallel();
+  }
+}
+
+EquivalenceCheckingManager::EquivalenceCheckingManager(
+    const qc::QuantumComputation& qc1, const qc::QuantumComputation& qc2,
+    const Configuration& configuration)
+    : qc1(qc1.size() > qc2.size() ? qc2.clone() : qc1.clone()),
+      qc2(qc1.size() > qc2.size() ? qc1.clone() : qc2.clone()),
+      configuration(configuration) {
+  // clones both circuits (the circuit with fewer gates always gets to be qc1)
+
+  const auto start = std::chrono::steady_clock::now();
+
+  // set numeric tolerance used throughout the check
+  setTolerance(configuration.execution.numericalTolerance);
+
+  // run all configured optimization passes
+  runOptimizationPasses();
+
+  // strip away qubits that are not acted upon
+  this->qc1.stripIdleQubits();
+  this->qc2.stripIdleQubits();
+
+  // given that one circuit has more qubits than the other, the difference is
+  // assumed to arise from ancillary qubits. adjust both circuits accordingly
+  setupAncillariesAndGarbage();
+
+  if (this->qc1.getNqubitsWithoutAncillae() !=
+      this->qc2.getNqubitsWithoutAncillae()) {
+    std::clog << "[QCEC] Warning: circuits have different number of primary "
+                 "inputs! Proceed with caution!"
+              << std::endl;
+  }
+
+  // try to fix a potential mismatch in the output permutations of both circuits
+  if (configuration.optimizations.fixOutputPermutationMismatch) {
+    fixOutputPermutationMismatch();
+  }
+
+  // initialize the stimuli generator
+  stateGenerator = StateGenerator(configuration.simulation.seed);
+
+  // check whether the number of selected stimuli does exceed the maximum number
+  // of unique computational basis states
+  if (configuration.execution.runSimulationChecker &&
+      configuration.simulation.stateType == StateType::ComputationalBasis) {
+    const auto        nq           = this->qc1.getNqubitsWithoutAncillae();
+    const std::size_t uniqueStates = 1ULL << nq;
+    if (nq <= 63U && configuration.simulation.maxSims > uniqueStates) {
+      this->configuration.simulation.maxSims = uniqueStates;
+    }
+  }
+
+  const auto end = std::chrono::steady_clock::now();
+  results.preprocessingTime =
+      std::chrono::duration<double>(end - start).count();
+}
+
+void EquivalenceCheckingManager::checkSequential() {
+  const auto start = std::chrono::steady_clock::now();
+
+  // in case a timeout is configured, a separate thread is started that sets the
+  // `done` flag after the timeout has passed
+  std::thread timeoutThread{};
+  if (configuration.execution.timeout > 0s) {
+    timeoutThread =
+        std::thread([this, timeout = configuration.execution.timeout] {
+          std::unique_lock doneLock(doneMutex);
+          auto             finished =
+              doneCond.wait_for(doneLock, timeout, [this] { return done; });
+          // if the thread has already finished within the timeout, nothing has
+          // to be done
+          if (!finished) {
+            done = true;
+          }
+        });
+  }
+
+  if (configuration.execution.runSimulationChecker) {
+    checkers.emplace_back(
+        std::make_unique<DDSimulationChecker>(qc1, qc2, configuration));
+    auto* simulationChecker =
+        dynamic_cast<DDSimulationChecker*>(checkers.back().get());
+    while (results.startedSimulations < configuration.simulation.maxSims &&
+           !done) {
+      // configure simulation based checker
+      simulationChecker->setRandomInitialState(stateGenerator);
+
+      // run the simulation
+      ++results.startedSimulations;
+      const auto result = simulationChecker->run();
+      ++results.performedSimulations;
+
+      // if the run completed but has not yielded any information this indicates
+      // a timeout
+      if (result == EquivalenceCriterion::NoInformation) {
+        if (!done) {
+          std::clog << "Simulation run returned without any information. "
+                       "Something probably went wrong. Exiting!"
+                    << std::endl;
+        }
+        return;
+      }
+
+      // break if non-equivalence has been shown
+      if (result == EquivalenceCriterion::NotEquivalent) {
+        results.equivalence = EquivalenceCriterion::NotEquivalent;
+        break;
+      }
+
+      // Otherwise, circuits are probably equivalent and execution can continue
+      results.equivalence = EquivalenceCriterion::ProbablyEquivalent;
     }
 
-    void EquivalenceCheckingManager::run() {
-        done                = false;
-        results.equivalence = EquivalenceCriterion::NoInformation;
+    // Circuits have been shown to be non-equivalent
+    if (results.equivalence == EquivalenceCriterion::NotEquivalent) {
+      if (configuration.simulation.storeCEXinput) {
+        results.cexInput = simulationChecker->getInitialVector();
+      }
+      if (configuration.simulation.storeCEXoutput) {
+        results.cexOutput1 = simulationChecker->getInternalVector1();
+        results.cexOutput2 = simulationChecker->getInternalVector2();
+      }
 
-        if (!configuration.anythingToExecute()) {
-            std::clog << "Nothing to be executed. Check your configuration!" << std::endl;
-            return;
-        }
-
-        if (!configuration.execution.parallel || configuration.execution.nthreads <= 1 || configuration.onlySingleTask()) {
-            checkSequential();
-        } else {
-            checkParallel();
-        }
+      // everything is done
+      done = true;
+      doneCond.notify_one();
     }
 
-    EquivalenceCheckingManager::EquivalenceCheckingManager(const qc::QuantumComputation& qc1, const qc::QuantumComputation& qc2, const Configuration& configuration):
-        qc1(qc1.size() > qc2.size() ? qc2.clone() : qc1.clone()),
-        qc2(qc1.size() > qc2.size() ? qc1.clone() : qc2.clone()),
-        configuration(configuration) {
-        // clones both circuits (the circuit with fewer gates always gets to be qc1)
+    // in case only simulations are performed and every single one is done,
+    // everything is done
+    if (!configuration.execution.runAlternatingChecker &&
+        !configuration.execution.runConstructionChecker &&
+        results.performedSimulations == configuration.simulation.maxSims) {
+      done = true;
+      doneCond.notify_one();
+    }
+  }
 
-        const auto start = std::chrono::steady_clock::now();
+  if (configuration.execution.runAlternatingChecker && !done) {
+    checkers.emplace_back(
+        std::make_unique<DDAlternatingChecker>(qc1, qc2, configuration));
+    const auto& alternatingChecker = checkers.back();
+    const auto  result             = alternatingChecker->run();
 
-        // set numeric tolerance used throughout the check
-        setTolerance(configuration.execution.numericalTolerance);
+    // if the alternating check produces a result, this is final
+    if (result != EquivalenceCriterion::NoInformation) {
+      results.equivalence = result;
 
-        // run all configured optimization passes
-        runOptimizationPasses();
+      // everything is done
+      done = true;
+      doneCond.notify_one();
+    }
+  }
 
-        // strip away qubits that are not acted upon
-        this->qc1.stripIdleQubits();
-        this->qc2.stripIdleQubits();
+  if (configuration.execution.runConstructionChecker && !done) {
+    checkers.emplace_back(
+        std::make_unique<DDConstructionChecker>(qc1, qc2, configuration));
+    const auto& constructionChecker = checkers.back();
+    const auto  result              = constructionChecker->run();
 
-        // given that one circuit has more qubits than the other, the difference is assumed to arise from ancillary qubits.
-        // adjust both circuits accordingly
-        setupAncillariesAndGarbage();
+    // if the construction check produces a result, this is final
+    if (result != EquivalenceCriterion::NoInformation) {
+      results.equivalence = result;
 
-        if (this->qc1.getNqubitsWithoutAncillae() != this->qc2.getNqubitsWithoutAncillae()) {
-            std::clog << "[QCEC] Warning: circuits have different number of primary inputs! Proceed with caution!" << std::endl;
+      // everything is done
+      done = true;
+      doneCond.notify_one();
+    }
+  }
+
+  if (configuration.execution.runZXChecker && !done) {
+    if (zx::FunctionalityConstruction::transformableToZX(&qc1) &&
+        zx::FunctionalityConstruction::transformableToZX(&qc2)) {
+      checkers.emplace_back(
+          std::make_unique<ZXEquivalenceChecker>(qc1, qc2, configuration));
+      const auto& zxChecker = checkers.back();
+      const auto  result    = zxChecker->run();
+
+      results.equivalence = result;
+      // break if equivalence has been shown
+      if (result == EquivalenceCriterion::EquivalentUpToGlobalPhase) {
+        done = true;
+        doneCond.notify_one();
+      }
+    } else if (configuration.onlyZXCheckerConfigured()) {
+      std::clog << "Only ZX checker specified but one of the circuits contains "
+                   "operations not supported by this checker! Exiting!"
+                << std::endl;
+      checkers.clear();
+      results.equivalence = EquivalenceCriterion::NoInformation;
+      return;
+    }
+  }
+
+  const auto end    = std::chrono::steady_clock::now();
+  results.checkTime = std::chrono::duration<double>(end - start).count();
+
+  // appropriately join the timeout thread, if it was launched
+  if (timeoutThread.joinable()) {
+    timeoutThread.join();
+  }
+}
+
+void EquivalenceCheckingManager::checkParallel() {
+  const auto start = std::chrono::steady_clock::now();
+
+  std::chrono::steady_clock::time_point deadline{};
+  if (configuration.execution.timeout > 0s) {
+    deadline = start + configuration.execution.timeout;
+  }
+
+  if (const auto threadLimit = std::thread::hardware_concurrency();
+      threadLimit != 0U && configuration.execution.nthreads > threadLimit) {
+    std::clog
+        << "Trying to use more threads than the underlying architecture claims "
+           "to support. Over-subscription might impact performance!"
+        << std::endl;
+  }
+
+  const auto maxThreads      = configuration.execution.nthreads;
+  const auto runAlternating  = configuration.execution.runAlternatingChecker;
+  const auto runConstruction = configuration.execution.runConstructionChecker;
+  const auto runZX           = configuration.execution.runZXChecker;
+  const auto runSimulation   = configuration.execution.runSimulationChecker &&
+                             configuration.simulation.maxSims > 0;
+
+  const std::size_t tasksToExecute =
+      configuration.simulation.maxSims * (static_cast<int>(runSimulation)) +
+      (runAlternating ? 1U : 0U) + (runConstruction ? 1U : 0U) +
+      (runZX ? 1U : 0U);
+
+  const auto effectiveThreads = std::min(maxThreads, tasksToExecute);
+
+  // reserve space for as many equivalence checkers as there will be parallel
+  // threads
+  checkers.resize(effectiveThreads);
+
+  // create a thread safe queue which is used to check for available results
+  ThreadSafeQueue<std::size_t> queue{};
+  std::size_t                  id = 0U;
+
+  // reserve space for the threads
+  std::vector<std::thread> threads{};
+  threads.reserve(effectiveThreads);
+
+  if (runAlternating) {
+    // start a new thread that constructs and runs the alternating check
+    threads.emplace_back([this, &queue, id] {
+      checkers[id] =
+          std::make_unique<DDAlternatingChecker>(qc1, qc2, configuration);
+      checkers[id]->run();
+      queue.push(id);
+    });
+    ++id;
+  }
+
+  if (runConstruction && !done) {
+    // start a new thread that constructs and runs the construction check
+    threads.emplace_back([this, &queue, id] {
+      checkers[id] =
+          std::make_unique<DDConstructionChecker>(qc1, qc2, configuration);
+      if (!done) {
+        checkers[id]->run();
+      }
+      queue.push(id);
+    });
+    ++id;
+  }
+
+  if (runZX && !done) {
+    if (zx::FunctionalityConstruction::transformableToZX(&qc1) &&
+        zx::FunctionalityConstruction::transformableToZX(&qc2)) {
+      // start a new thread that constructs and runs the ZX checker
+      threads.emplace_back([this, &queue, id] {
+        checkers[id] =
+            std::make_unique<ZXEquivalenceChecker>(qc1, qc2, configuration);
+        if (!done) {
+          checkers[id]->run();
         }
+        queue.push(id);
+      });
+      ++id;
+    } else if (configuration.onlyZXCheckerConfigured()) {
+      std::clog << "Only ZX checker specified but one of the circuits contains "
+                   "operations not supported by this checker! Exiting!"
+                << std::endl;
+      checkers.clear();
+      results.equivalence = EquivalenceCriterion::NoInformation;
+      done                = true;
+    }
+  }
 
-        // try to fix a potential mismatch in the output permutations of both circuits
-        if (configuration.optimizations.fixOutputPermutationMismatch) {
-            fixOutputPermutationMismatch();
+  if (runSimulation) {
+    const auto effectiveThreadsLeft = effectiveThreads - threads.size();
+    // launch as many simulations as possible
+    for (std::size_t i = 0; i < effectiveThreadsLeft && !done; ++i) {
+      threads.emplace_back([this, &queue, id] {
+        checkers[id] =
+            std::make_unique<DDSimulationChecker>(qc1, qc2, configuration);
+        auto* checker = dynamic_cast<DDSimulationChecker*>(checkers[id].get());
+        {
+          std::lock_guard stateGeneratorLock(stateGeneratorMutex);
+          checker->setRandomInitialState(stateGenerator);
         }
-
-        // initialize the stimuli generator
-        stateGenerator = StateGenerator(configuration.simulation.seed);
-
-        // check whether the number of selected stimuli does exceed the maximum number of unique computational basis states
-        if (configuration.execution.runSimulationChecker && configuration.simulation.stateType == StateType::ComputationalBasis) {
-            const auto        nq           = this->qc1.getNqubitsWithoutAncillae();
-            const std::size_t uniqueStates = 1ULL << nq;
-            if (nq <= 63U && configuration.simulation.maxSims > uniqueStates) {
-                this->configuration.simulation.maxSims = uniqueStates;
-            }
+        if (!done) {
+          checkers[id]->run();
         }
+        queue.push(id);
+      });
+      ++id;
+      ++results.startedSimulations;
+    }
+  }
 
-        const auto end            = std::chrono::steady_clock::now();
-        results.preprocessingTime = std::chrono::duration<double>(end - start).count();
+  // wait in a loop while no definitive result has been obtained
+  while (!done) {
+    std::shared_ptr<std::size_t> completedID{};
+    if (configuration.execution.timeout > 0s) {
+      completedID = queue.waitAndPopUntil(deadline);
+    } else {
+      completedID = queue.waitAndPop();
     }
 
-    void EquivalenceCheckingManager::checkSequential() {
-        const auto start = std::chrono::steady_clock::now();
-
-        // in case a timeout is configured, a separate thread is started that sets the `done` flag after the timeout has passed
-        std::thread timeoutThread{};
-        if (configuration.execution.timeout > 0s) {
-            timeoutThread = std::thread([this, timeout = configuration.execution.timeout] {
-                std::unique_lock doneLock(doneMutex);
-                auto             finished = doneCond.wait_for(doneLock, timeout, [this] { return done; });
-                // if the thread has already finished within the timeout, nothing has to be done
-                if (!finished) {
-                    done = true;
-                }
-            });
-        }
-
-        if (configuration.execution.runSimulationChecker) {
-            checkers.emplace_back(std::make_unique<DDSimulationChecker>(qc1, qc2, configuration));
-            auto* simulationChecker = dynamic_cast<DDSimulationChecker*>(checkers.back().get());
-            while (results.startedSimulations < configuration.simulation.maxSims && !done) {
-                // configure simulation based checker
-                simulationChecker->setRandomInitialState(stateGenerator);
-
-                // run the simulation
-                ++results.startedSimulations;
-                const auto result = simulationChecker->run();
-                ++results.performedSimulations;
-
-                // if the run completed but has not yielded any information this indicates a timeout
-                if (result == EquivalenceCriterion::NoInformation) {
-                    if (!done) {
-                        std::clog << "Simulation run returned without any information. Something probably went wrong. Exiting!" << std::endl;
-                    }
-                    return;
-                }
-
-                // break if non-equivalence has been shown
-                if (result == EquivalenceCriterion::NotEquivalent) {
-                    results.equivalence = EquivalenceCriterion::NotEquivalent;
-                    break;
-                }
-
-                // Otherwise, circuits are probably equivalent and execution can continue
-                results.equivalence = EquivalenceCriterion::ProbablyEquivalent;
-            }
-
-            // Circuits have been shown to be non-equivalent
-            if (results.equivalence == EquivalenceCriterion::NotEquivalent) {
-                if (configuration.simulation.storeCEXinput) {
-                    results.cexInput = simulationChecker->getInitialVector();
-                }
-                if (configuration.simulation.storeCEXoutput) {
-                    results.cexOutput1 = simulationChecker->getInternalVector1();
-                    results.cexOutput2 = simulationChecker->getInternalVector2();
-                }
-
-                // everything is done
-                done = true;
-                doneCond.notify_one();
-            }
-
-            // in case only simulations are performed and every single one is done, everything is done
-            if (!configuration.execution.runAlternatingChecker &&
-                !configuration.execution.runConstructionChecker &&
-                results.performedSimulations == configuration.simulation.maxSims) {
-                done = true;
-                doneCond.notify_one();
-            }
-        }
-
-        if (configuration.execution.runAlternatingChecker && !done) {
-            checkers.emplace_back(std::make_unique<DDAlternatingChecker>(qc1, qc2, configuration));
-            const auto& alternatingChecker = checkers.back();
-            const auto  result             = alternatingChecker->run();
-
-            // if the alternating check produces a result, this is final
-            if (result != EquivalenceCriterion::NoInformation) {
-                results.equivalence = result;
-
-                // everything is done
-                done = true;
-                doneCond.notify_one();
-            }
-        }
-
-        if (configuration.execution.runConstructionChecker && !done) {
-            checkers.emplace_back(std::make_unique<DDConstructionChecker>(qc1, qc2, configuration));
-            const auto& constructionChecker = checkers.back();
-            const auto  result              = constructionChecker->run();
-
-            // if the construction check produces a result, this is final
-            if (result != EquivalenceCriterion::NoInformation) {
-                results.equivalence = result;
-
-                // everything is done
-                done = true;
-                doneCond.notify_one();
-            }
-        }
-
-        if (configuration.execution.runZXChecker && !done) {
-            if (zx::FunctionalityConstruction::transformableToZX(&qc1) && zx::FunctionalityConstruction::transformableToZX(&qc2)) {
-                checkers.emplace_back(std::make_unique<ZXEquivalenceChecker>(qc1, qc2, configuration));
-                const auto& zxChecker = checkers.back();
-                const auto  result    = zxChecker->run();
-
-                results.equivalence = result;
-                // break if equivalence has been shown
-                if (result == EquivalenceCriterion::EquivalentUpToGlobalPhase) {
-                    done = true;
-                    doneCond.notify_one();
-                }
-            } else if (configuration.onlyZXCheckerConfigured()) {
-                std::clog << "Only ZX checker specified but one of the circuits contains operations not supported by this checker! Exiting!" << std::endl;
-                checkers.clear();
-                results.equivalence = EquivalenceCriterion::NoInformation;
-                return;
-            }
-        }
-
-        const auto end    = std::chrono::steady_clock::now();
-        results.checkTime = std::chrono::duration<double>(end - start).count();
-
-        // appropriately join the timeout thread, if it was launched
-        if (timeoutThread.joinable()) {
-            timeoutThread.join();
-        }
+    // in case no completed ID has been returned this indicates a timeout and
+    // the computation should stop
+    if (!completedID) {
+      setAndSignalDone();
+      break;
     }
 
-    void EquivalenceCheckingManager::checkParallel() {
-        const auto start = std::chrono::steady_clock::now();
+    // otherwise, a checker has finished its execution
+    // join the respective thread (which should return immediately)
+    threads.at(*completedID).join();
 
-        std::chrono::steady_clock::time_point deadline{};
-        if (configuration.execution.timeout > 0s) {
-            deadline = start + configuration.execution.timeout;
-        }
+    // in case non-equivalence has been shown, the execution can be stopped
+    auto*      checker = checkers.at(*completedID).get();
+    const auto result  = checker->getEquivalence();
 
-        if (const auto threadLimit = std::thread::hardware_concurrency(); threadLimit != 0U && configuration.execution.nthreads > threadLimit) {
-            std::clog << "Trying to use more threads than the underlying architecture claims to support. Over-subscription might impact performance!" << std::endl;
-        }
-
-        const auto maxThreads      = configuration.execution.nthreads;
-        const auto runAlternating  = configuration.execution.runAlternatingChecker;
-        const auto runConstruction = configuration.execution.runConstructionChecker;
-        const auto runZX           = configuration.execution.runZXChecker;
-        const auto runSimulation   = configuration.execution.runSimulationChecker && configuration.simulation.maxSims > 0;
-
-        const std::size_t tasksToExecute = configuration.simulation.maxSims * (static_cast<int>(runSimulation)) +
-                                           (runAlternating ? 1U : 0U) +
-                                           (runConstruction ? 1U : 0U) +
-                                           (runZX ? 1U : 0U);
-
-        const auto effectiveThreads = std::min(maxThreads, tasksToExecute);
-
-        // reserve space for as many equivalence checkers as there will be parallel threads
-        checkers.resize(effectiveThreads);
-
-        // create a thread safe queue which is used to check for available results
-        ThreadSafeQueue<std::size_t> queue{};
-        std::size_t                  id = 0U;
-
-        // reserve space for the threads
-        std::vector<std::thread> threads{};
-        threads.reserve(effectiveThreads);
-
-        if (runAlternating) {
-            // start a new thread that constructs and runs the alternating check
-            threads.emplace_back([this, &queue, id] {
-                checkers[id] = std::make_unique<DDAlternatingChecker>(qc1, qc2, configuration);
-                checkers[id]->run();
-                queue.push(id);
-            });
-            ++id;
-        }
-
-        if (runConstruction && !done) {
-            // start a new thread that constructs and runs the construction check
-            threads.emplace_back([this, &queue, id] {
-                checkers[id] = std::make_unique<DDConstructionChecker>(qc1, qc2, configuration);
-                if (!done) {
-                    checkers[id]->run();
-                }
-                queue.push(id);
-            });
-            ++id;
-        }
-
-        if (runZX && !done) {
-            if (zx::FunctionalityConstruction::transformableToZX(&qc1) && zx::FunctionalityConstruction::transformableToZX(&qc2)) {
-                // start a new thread that constructs and runs the ZX checker
-                threads.emplace_back([this, &queue, id] {
-                    checkers[id] = std::make_unique<ZXEquivalenceChecker>(qc1, qc2, configuration);
-                    if (!done) {
-                        checkers[id]->run();
-                    }
-                    queue.push(id);
-                });
-                ++id;
-            } else if (configuration.onlyZXCheckerConfigured()) {
-                std::clog << "Only ZX checker specified but one of the circuits contains operations not supported by this checker! Exiting!" << std::endl;
-                checkers.clear();
-                results.equivalence = EquivalenceCriterion::NoInformation;
-                done                = true;
-            }
-        }
-
-        if (runSimulation) {
-            const auto effectiveThreadsLeft = effectiveThreads - threads.size();
-            // launch as many simulations as possible
-            for (std::size_t i = 0; i < effectiveThreadsLeft && !done; ++i) {
-                threads.emplace_back([this, &queue, id] {
-                    checkers[id]  = std::make_unique<DDSimulationChecker>(qc1, qc2, configuration);
-                    auto* checker = dynamic_cast<DDSimulationChecker*>(checkers[id].get());
-                    {
-                        std::lock_guard stateGeneratorLock(stateGeneratorMutex);
-                        checker->setRandomInitialState(stateGenerator);
-                    }
-                    if (!done) {
-                        checkers[id]->run();
-                    }
-                    queue.push(id);
-                });
-                ++id;
-                ++results.startedSimulations;
-            }
-        }
-
-        // wait in a loop while no definitive result has been obtained
-        while (!done) {
-            std::shared_ptr<std::size_t> completedID{};
-            if (configuration.execution.timeout > 0s) {
-                completedID = queue.waitAndPopUntil(deadline);
-            } else {
-                completedID = queue.waitAndPop();
-            }
-
-            // in case no completed ID has been returned this indicates a timeout and the computation should stop
-            if (!completedID) {
-                setAndSignalDone();
-                break;
-            }
-
-            // otherwise, a checker has finished its execution
-            // join the respective thread (which should return immediately)
-            threads.at(*completedID).join();
-
-            // in case non-equivalence has been shown, the execution can be stopped
-            auto*      checker = checkers.at(*completedID).get();
-            const auto result  = checker->getEquivalence();
-
-            if (result == EquivalenceCriterion::NoInformation) {
-                std::clog << "Finished equivalence check provides no information. Something probably went wrong. Exiting." << std::endl;
-                break;
-            }
-
-            if (result == EquivalenceCriterion::NotEquivalent) {
-                setAndSignalDone();
-                results.equivalence = result;
-
-                // some special handling in case non-equivalence has been shown by a simulation run
-                if (auto* simulationChecker = dynamic_cast<DDSimulationChecker*>(checker)) {
-                    results.performedSimulations++;
-
-                    if (configuration.simulation.storeCEXinput) {
-                        results.cexInput = simulationChecker->getInitialVector();
-                    }
-                    if (configuration.simulation.storeCEXoutput) {
-                        results.cexOutput1 = simulationChecker->getInternalVector1();
-                        results.cexOutput2 = simulationChecker->getInternalVector2();
-                    }
-                }
-
-                break;
-            }
-
-            // the alternating and the construction checker provide definitive answers once they finish
-            if ((dynamic_cast<DDAlternatingChecker*>(checker) != nullptr) ||
-                (dynamic_cast<DDConstructionChecker*>(checker) != nullptr)) {
-                setAndSignalDone();
-                results.equivalence = result;
-                break;
-            }
-
-            if (dynamic_cast<ZXEquivalenceChecker*>(checker) != nullptr) {
-                results.equivalence = result;
-                if (result == EquivalenceCriterion::EquivalentUpToGlobalPhase || (result == EquivalenceCriterion::ProbablyNotEquivalent && configuration.onlyZXCheckerConfigured())) {
-                    setAndSignalDone();
-                    break;
-                }
-                // The ZX checker cannot conclude non-equivalence so the run is not stopped
-            }
-
-            // at this point, the only option is that this is a simulation checker
-            if (dynamic_cast<DDSimulationChecker*>(checker) != nullptr) {
-                // if the simulation has not shown the non-equivalence, then both circuits are considered probably equivalent
-                results.equivalence = EquivalenceCriterion::ProbablyEquivalent;
-                ++results.performedSimulations;
-
-                // it has to be checked, whether further simulations shall be conducted
-                if (results.startedSimulations < configuration.simulation.maxSims) {
-                    threads[*completedID] = std::thread([&, this, id = *completedID] {
-                        auto* simChecker = dynamic_cast<DDSimulationChecker*>(checkers[id].get());
-                        {
-                            std::lock_guard stateGeneratorLock(stateGeneratorMutex);
-                            simChecker->setRandomInitialState(stateGenerator);
-                        }
-                        if (!done) {
-                            checkers[id]->run();
-                        }
-                        queue.push(id);
-                    });
-                    ++results.startedSimulations;
-                } else if (configuration.onlySimulationCheckerConfigured() && results.performedSimulations == configuration.simulation.maxSims) {
-                    // in case only simulations are performed and every single one is done, everything is done
-                    setAndSignalDone();
-                    break;
-                }
-            }
-        }
-
-        const auto end    = std::chrono::steady_clock::now();
-        results.checkTime = std::chrono::duration<double>(end - start).count();
-
-        // cleanup threads that are still running by joining them
-        // start by joining all the completed threads, which should succeed instantly
-        while (!queue.empty()) {
-            const auto completedID = queue.waitAndPop();
-            auto&      thread      = threads.at(*completedID);
-            if (thread.joinable()) {
-                thread.join();
-            }
-        }
-
-        // afterwards, join all threads that are still (potentially) running.
-        // at the moment there seems to be no solution for prematurely killing running threads without risking synchronisation issues.
-        // on the positive side, joining should avoid all of these potential issues
-        // on the negative side, one of the threads might still be stuck in a long-running operation and does not check for the `done` signal until this operation completes
-        for (auto& thread: threads) {
-            if (thread.joinable()) {
-                thread.join();
-            }
-        }
+    if (result == EquivalenceCriterion::NoInformation) {
+      std::clog << "Finished equivalence check provides no information. "
+                   "Something probably went wrong. Exiting."
+                << std::endl;
+      break;
     }
 
-    nlohmann::json EquivalenceCheckingManager::json() const {
-        nlohmann::json res{};
+    if (result == EquivalenceCriterion::NotEquivalent) {
+      setAndSignalDone();
+      results.equivalence = result;
 
-        addCircuitDescription(qc1, res["circuit1"]);
-        addCircuitDescription(qc2, res["circuit2"]);
-        res["configuration"] = configuration.json();
-        res["results"]       = results.json();
+      // some special handling in case non-equivalence has been shown by a
+      // simulation run
+      if (auto* simulationChecker =
+              dynamic_cast<DDSimulationChecker*>(checker)) {
+        results.performedSimulations++;
 
-        if (!checkers.empty()) {
-            res["checkers"]      = nlohmann::json::array();
-            auto& checkerResults = res["checkers"];
-            for (const auto& checker: checkers) {
-                nlohmann::json j{};
-                checker->json(j);
-                checkerResults.push_back(j);
-            }
+        if (configuration.simulation.storeCEXinput) {
+          results.cexInput = simulationChecker->getInitialVector();
         }
-        return res;
-    }
-    void EquivalenceCheckingManager::runFixOutputPermutationMismatch() {
-        if (!configuration.optimizations.fixOutputPermutationMismatch) {
-            fixOutputPermutationMismatch();
-            configuration.optimizations.fixOutputPermutationMismatch = true;
+        if (configuration.simulation.storeCEXoutput) {
+          results.cexOutput1 = simulationChecker->getInternalVector1();
+          results.cexOutput2 = simulationChecker->getInternalVector2();
         }
-    }
-    void EquivalenceCheckingManager::fuseSingleQubitGates() {
-        if (!configuration.optimizations.fuseSingleQubitGates) {
-            qc::CircuitOptimizer::singleQubitGateFusion(qc1);
-            qc::CircuitOptimizer::singleQubitGateFusion(qc2);
-            configuration.optimizations.fuseSingleQubitGates = true;
-        }
-    }
-    void EquivalenceCheckingManager::reconstructSWAPs() {
-        if (!configuration.optimizations.reconstructSWAPs) {
-            qc::CircuitOptimizer::swapReconstruction(qc1);
-            qc::CircuitOptimizer::swapReconstruction(qc2);
-            configuration.optimizations.reconstructSWAPs = true;
-        }
-    }
-    void EquivalenceCheckingManager::reorderOperations() {
-        if (!configuration.optimizations.reorderOperations) {
-            qc::CircuitOptimizer::reorderOperations(qc1);
-            qc::CircuitOptimizer::reorderOperations(qc2);
-            configuration.optimizations.reorderOperations = true;
-        }
-    }
-    nlohmann::json EquivalenceCheckingManager::Results::json() const {
-        nlohmann::json res{};
-        res["preprocessing_time"] = preprocessingTime;
-        res["check_time"]         = checkTime;
-        res["equivalence"]        = ec::toString(equivalence);
+      }
 
-        if (startedSimulations > 0) {
-            auto& sim        = res["simulations"];
-            sim["started"]   = startedSimulations;
-            sim["performed"] = performedSimulations;
-
-            if (!cexInput.empty() || !cexOutput1.empty() || !cexOutput2.empty()) {
-                auto& cex = sim["verification_cex"];
-                if (!cexInput.empty()) {
-                    toJson(cex["input"], cexInput);
-                }
-                if (!cexOutput1.empty()) {
-                    toJson(cex["output1"], cexOutput1);
-                }
-                if (!cexOutput2.empty()) {
-                    toJson(cex["output2"], cexOutput2);
-                }
-            }
-        }
-
-        return res;
+      break;
     }
+
+    // the alternating and the construction checker provide definitive answers
+    // once they finish
+    if ((dynamic_cast<DDAlternatingChecker*>(checker) != nullptr) ||
+        (dynamic_cast<DDConstructionChecker*>(checker) != nullptr)) {
+      setAndSignalDone();
+      results.equivalence = result;
+      break;
+    }
+
+    if (dynamic_cast<ZXEquivalenceChecker*>(checker) != nullptr) {
+      results.equivalence = result;
+      if (result == EquivalenceCriterion::EquivalentUpToGlobalPhase ||
+          (result == EquivalenceCriterion::ProbablyNotEquivalent &&
+           configuration.onlyZXCheckerConfigured())) {
+        setAndSignalDone();
+        break;
+      }
+      // The ZX checker cannot conclude non-equivalence so the run is not
+      // stopped
+    }
+
+    // at this point, the only option is that this is a simulation checker
+    if (dynamic_cast<DDSimulationChecker*>(checker) != nullptr) {
+      // if the simulation has not shown the non-equivalence, then both circuits
+      // are considered probably equivalent
+      results.equivalence = EquivalenceCriterion::ProbablyEquivalent;
+      ++results.performedSimulations;
+
+      // it has to be checked, whether further simulations shall be conducted
+      if (results.startedSimulations < configuration.simulation.maxSims) {
+        threads[*completedID] = std::thread([&, this, id = *completedID] {
+          auto* simChecker =
+              dynamic_cast<DDSimulationChecker*>(checkers[id].get());
+          {
+            std::lock_guard stateGeneratorLock(stateGeneratorMutex);
+            simChecker->setRandomInitialState(stateGenerator);
+          }
+          if (!done) {
+            checkers[id]->run();
+          }
+          queue.push(id);
+        });
+        ++results.startedSimulations;
+      } else if (configuration.onlySimulationCheckerConfigured() &&
+                 results.performedSimulations ==
+                     configuration.simulation.maxSims) {
+        // in case only simulations are performed and every single one is done,
+        // everything is done
+        setAndSignalDone();
+        break;
+      }
+    }
+  }
+
+  const auto end    = std::chrono::steady_clock::now();
+  results.checkTime = std::chrono::duration<double>(end - start).count();
+
+  // cleanup threads that are still running by joining them
+  // start by joining all the completed threads, which should succeed instantly
+  while (!queue.empty()) {
+    const auto completedID = queue.waitAndPop();
+    auto&      thread      = threads.at(*completedID);
+    if (thread.joinable()) {
+      thread.join();
+    }
+  }
+
+  // afterwards, join all threads that are still (potentially) running.
+  // at the moment there seems to be no solution for prematurely killing running
+  // threads without risking synchronisation issues. on the positive side,
+  // joining should avoid all of these potential issues on the negative side,
+  // one of the threads might still be stuck in a long-running operation and
+  // does not check for the `done` signal until this operation completes
+  for (auto& thread : threads) {
+    if (thread.joinable()) {
+      thread.join();
+    }
+  }
+}
+
+nlohmann::json EquivalenceCheckingManager::json() const {
+  nlohmann::json res{};
+
+  addCircuitDescription(qc1, res["circuit1"]);
+  addCircuitDescription(qc2, res["circuit2"]);
+  res["configuration"] = configuration.json();
+  res["results"]       = results.json();
+
+  if (!checkers.empty()) {
+    res["checkers"]      = nlohmann::json::array();
+    auto& checkerResults = res["checkers"];
+    for (const auto& checker : checkers) {
+      nlohmann::json j{};
+      checker->json(j);
+      checkerResults.push_back(j);
+    }
+  }
+  return res;
+}
+void EquivalenceCheckingManager::runFixOutputPermutationMismatch() {
+  if (!configuration.optimizations.fixOutputPermutationMismatch) {
+    fixOutputPermutationMismatch();
+    configuration.optimizations.fixOutputPermutationMismatch = true;
+  }
+}
+void EquivalenceCheckingManager::fuseSingleQubitGates() {
+  if (!configuration.optimizations.fuseSingleQubitGates) {
+    qc::CircuitOptimizer::singleQubitGateFusion(qc1);
+    qc::CircuitOptimizer::singleQubitGateFusion(qc2);
+    configuration.optimizations.fuseSingleQubitGates = true;
+  }
+}
+void EquivalenceCheckingManager::reconstructSWAPs() {
+  if (!configuration.optimizations.reconstructSWAPs) {
+    qc::CircuitOptimizer::swapReconstruction(qc1);
+    qc::CircuitOptimizer::swapReconstruction(qc2);
+    configuration.optimizations.reconstructSWAPs = true;
+  }
+}
+void EquivalenceCheckingManager::reorderOperations() {
+  if (!configuration.optimizations.reorderOperations) {
+    qc::CircuitOptimizer::reorderOperations(qc1);
+    qc::CircuitOptimizer::reorderOperations(qc2);
+    configuration.optimizations.reorderOperations = true;
+  }
+}
+nlohmann::json EquivalenceCheckingManager::Results::json() const {
+  nlohmann::json res{};
+  res["preprocessing_time"] = preprocessingTime;
+  res["check_time"]         = checkTime;
+  res["equivalence"]        = ec::toString(equivalence);
+
+  if (startedSimulations > 0) {
+    auto& sim        = res["simulations"];
+    sim["started"]   = startedSimulations;
+    sim["performed"] = performedSimulations;
+
+    if (!cexInput.empty() || !cexOutput1.empty() || !cexOutput2.empty()) {
+      auto& cex = sim["verification_cex"];
+      if (!cexInput.empty()) {
+        toJson(cex["input"], cexInput);
+      }
+      if (!cexOutput1.empty()) {
+        toJson(cex["output1"], cexOutput1);
+      }
+      if (!cexOutput2.empty()) {
+        toJson(cex["output2"], cexOutput2);
+      }
+    }
+  }
+
+  return res;
+}
 } // namespace ec

--- a/src/checker/dd/DDAlternatingChecker.cpp
+++ b/src/checker/dd/DDAlternatingChecker.cpp
@@ -1,163 +1,172 @@
 //
-// This file is part of MQT QCEC library which is released under the MIT license.
-// See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
 #include "checker/dd/DDAlternatingChecker.hpp"
 
 namespace ec {
-    void DDAlternatingChecker::initialize() {
-        DDEquivalenceChecker::initialize();
-        // create the full identity matrix
-        functionality = dd->makeIdent(nqubits);
-        dd->incRef(functionality);
+void DDAlternatingChecker::initialize() {
+  DDEquivalenceChecker::initialize();
+  // create the full identity matrix
+  functionality = dd->makeIdent(nqubits);
+  dd->incRef(functionality);
 
-        // only count ancillaries that are present in but not acted upon in both of the circuits
-        // at the moment this is just to be on the safe side. It might be fine to also start with the
-        // reduced matrix for every ancillary without any restriction
-        // TODO: check whether the way ancillaries are handled here is theoretically sound
-        std::vector<bool> ancillary(nqubits);
-        for (auto q = static_cast<dd::Qubit>(nqubits - 1U); q >= 0; --q) {
-            if (qc1.logicalQubitIsAncillary(q) && qc2.logicalQubitIsAncillary(q)) {
-                bool found1  = false;
-                bool isIdle1 = false;
-                if (const auto it = std::find_if(qc1.initialLayout.cbegin(), qc1.initialLayout.cend(),
-                                                 [q](const auto& mapping) { return mapping.second == q; });
-                    it != qc1.initialLayout.cend()) {
-                    found1  = true;
-                    isIdle1 = qc1.isIdleQubit(it->first);
-                }
-                bool found2  = false;
-                bool isIdle2 = false;
-                if (const auto it = std::find_if(qc2.initialLayout.cbegin(), qc2.initialLayout.cend(),
-                                                 [q](const auto& mapping) { return mapping.second == q; });
-                    it != qc2.initialLayout.cend()) {
-                    found2  = true;
-                    isIdle2 = qc2.isIdleQubit(it->first);
-                }
+  // only count ancillaries that are present in but not acted upon in both of
+  // the circuits at the moment this is just to be on the safe side. It might be
+  // fine to also start with the reduced matrix for every ancillary without any
+  // restriction
+  // TODO: check whether the way ancillaries are handled here is theoretically
+  // sound
+  std::vector<bool> ancillary(nqubits);
+  for (auto q = static_cast<dd::Qubit>(nqubits - 1U); q >= 0; --q) {
+    if (qc1.logicalQubitIsAncillary(q) && qc2.logicalQubitIsAncillary(q)) {
+      bool found1  = false;
+      bool isIdle1 = false;
+      if (const auto it = std::find_if(
+              qc1.initialLayout.cbegin(), qc1.initialLayout.cend(),
+              [q](const auto& mapping) { return mapping.second == q; });
+          it != qc1.initialLayout.cend()) {
+        found1  = true;
+        isIdle1 = qc1.isIdleQubit(it->first);
+      }
+      bool found2  = false;
+      bool isIdle2 = false;
+      if (const auto it = std::find_if(
+              qc2.initialLayout.cbegin(), qc2.initialLayout.cend(),
+              [q](const auto& mapping) { return mapping.second == q; });
+          it != qc2.initialLayout.cend()) {
+        found2  = true;
+        isIdle2 = qc2.isIdleQubit(it->first);
+      }
 
-                // qubit only really exists or is acted on in one of the circuits
-                if ((found1 != found2) || (isIdle1 != isIdle2)) {
-                    ancillary[static_cast<std::size_t>(q)] = true;
-                }
-            }
-        }
-
-        // reduce the ancillary qubit contributions
-        // [1 0] if the qubit is no ancillary, or it is acted upon by both circuits
-        // [0 1]
-        //
-        // [1 0] for an ancillary that is present in one circuit and not acted upon in the other
-        // [0 0]
-        functionality = dd->reduceAncillae(functionality, ancillary);
+      // qubit only really exists or is acted on in one of the circuits
+      if ((found1 != found2) || (isIdle1 != isIdle2)) {
+        ancillary[static_cast<std::size_t>(q)] = true;
+      }
     }
+  }
 
-    void DDAlternatingChecker::execute() {
-        while (!taskManager1.finished() && !taskManager2.finished() && !isDone()) {
-            // skip over any SWAP operations
-            taskManager1.applySwapOperations(functionality);
-            taskManager2.applySwapOperations(functionality);
+  // reduce the ancillary qubit contributions
+  // [1 0] if the qubit is no ancillary, or it is acted upon by both circuits
+  // [0 1]
+  //
+  // [1 0] for an ancillary that is present in one circuit and not acted upon in
+  // the other [0 0]
+  functionality = dd->reduceAncillae(functionality, ancillary);
+}
 
-            if (!taskManager1.finished() && !taskManager2.finished()) {
-                if (isDone()) {
-                    return;
-                }
+void DDAlternatingChecker::execute() {
+  while (!taskManager1.finished() && !taskManager2.finished() && !isDone()) {
+    // skip over any SWAP operations
+    taskManager1.applySwapOperations(functionality);
+    taskManager2.applySwapOperations(functionality);
 
-                // whenever the current functionality resembles the identity, identical gates on both sides cancel
-                if (functionality.p->isIdentity() && (configuration.application.alternatingScheme != ApplicationSchemeType::Lookahead) && gatesAreIdentical()) {
-                    taskManager1.advanceIterator();
-                    taskManager2.advanceIterator();
-                    continue;
-                }
-                // query application scheme on how to proceed
-                const auto [apply1, apply2] = (*applicationScheme)();
+    if (!taskManager1.finished() && !taskManager2.finished()) {
+      if (isDone()) {
+        return;
+      }
 
-                // advance both tasks correspondingly
-                if (isDone()) {
-                    return;
-                }
-                taskManager1.advance(functionality, apply1);
-                if (isDone()) {
-                    return;
-                }
-                taskManager2.advance(functionality, apply2);
-            }
-        }
+      // whenever the current functionality resembles the identity, identical
+      // gates on both sides cancel
+      if (functionality.p->isIdentity() &&
+          (configuration.application.alternatingScheme !=
+           ApplicationSchemeType::Lookahead) &&
+          gatesAreIdentical()) {
+        taskManager1.advanceIterator();
+        taskManager2.advanceIterator();
+        continue;
+      }
+      // query application scheme on how to proceed
+      const auto [apply1, apply2] = (*applicationScheme)();
+
+      // advance both tasks correspondingly
+      if (isDone()) {
+        return;
+      }
+      taskManager1.advance(functionality, apply1);
+      if (isDone()) {
+        return;
+      }
+      taskManager2.advance(functionality, apply2);
     }
+  }
+}
 
-    void DDAlternatingChecker::finish() {
-        taskManager1.finish(functionality);
-        if (isDone()) {
-            return;
-        }
-        taskManager2.finish(functionality);
-    }
+void DDAlternatingChecker::finish() {
+  taskManager1.finish(functionality);
+  if (isDone()) {
+    return;
+  }
+  taskManager2.finish(functionality);
+}
 
-    void DDAlternatingChecker::postprocess() {
-        // ensure that the permutations that were tracked throughout the circuit match the expected output permutations
-        taskManager1.changePermutation(functionality);
-        if (isDone()) {
-            return;
-        }
-        taskManager2.changePermutation(functionality);
-        if (isDone()) {
-            return;
-        }
+void DDAlternatingChecker::postprocess() {
+  // ensure that the permutations that were tracked throughout the circuit match
+  // the expected output permutations
+  taskManager1.changePermutation(functionality);
+  if (isDone()) {
+    return;
+  }
+  taskManager2.changePermutation(functionality);
+  if (isDone()) {
+    return;
+  }
 
-        // sum up the contributions of garbage qubits
-        taskManager1.reduceGarbage(functionality);
-        if (isDone()) {
-            return;
-        }
-        taskManager2.reduceGarbage(functionality);
-        if (isDone()) {
-            return;
-        }
+  // sum up the contributions of garbage qubits
+  taskManager1.reduceGarbage(functionality);
+  if (isDone()) {
+    return;
+  }
+  taskManager2.reduceGarbage(functionality);
+  if (isDone()) {
+    return;
+  }
 
-        // TODO: check whether reducing ancillaries here is theoretically sound
-        taskManager1.reduceAncillae(functionality);
-        if (isDone()) {
-            return;
-        }
-        taskManager2.reduceAncillae(functionality);
-        if (isDone()) {
-            return;
-        }
-    }
+  // TODO: check whether reducing ancillaries here is theoretically sound
+  taskManager1.reduceAncillae(functionality);
+  if (isDone()) {
+    return;
+  }
+  taskManager2.reduceAncillae(functionality);
+  if (isDone()) {
+    return;
+  }
+}
 
-    EquivalenceCriterion DDAlternatingChecker::checkEquivalence() {
-        // create the full identity matrix
-        auto goalMatrix = dd->makeIdent(nqubits);
-        dd->incRef(goalMatrix);
+EquivalenceCriterion DDAlternatingChecker::checkEquivalence() {
+  // create the full identity matrix
+  auto goalMatrix = dd->makeIdent(nqubits);
+  dd->incRef(goalMatrix);
 
-        // account for any garbage
-        taskManager1.reduceGarbage(goalMatrix);
-        taskManager2.reduceGarbage(goalMatrix);
+  // account for any garbage
+  taskManager1.reduceGarbage(goalMatrix);
+  taskManager2.reduceGarbage(goalMatrix);
 
-        // TODO: check whether reducing ancillaries here is theoretically sound
-        taskManager1.reduceAncillae(goalMatrix);
-        taskManager2.reduceAncillae(goalMatrix);
+  // TODO: check whether reducing ancillaries here is theoretically sound
+  taskManager1.reduceAncillae(goalMatrix);
+  taskManager2.reduceAncillae(goalMatrix);
 
-        // the resulting goal matrix is
-        // [1 0] if the qubit is no ancillary
-        // [0 1]
-        //
-        // [1 0] for an ancillary that is present in either circuit
-        // [0 0]
+  // the resulting goal matrix is
+  // [1 0] if the qubit is no ancillary
+  // [0 1]
+  //
+  // [1 0] for an ancillary that is present in either circuit
+  // [0 0]
 
-        // compare the obtained functionality to the goal matrix
-        return equals(functionality, goalMatrix);
-    }
+  // compare the obtained functionality to the goal matrix
+  return equals(functionality, goalMatrix);
+}
 
-    [[nodiscard]] bool DDAlternatingChecker::gatesAreIdentical() const {
-        if (taskManager1.finished() || taskManager2.finished()) {
-            return false;
-        }
+[[nodiscard]] bool DDAlternatingChecker::gatesAreIdentical() const {
+  if (taskManager1.finished() || taskManager2.finished()) {
+    return false;
+  }
 
-        const auto& op1 = *taskManager1();
-        const auto& op2 = *taskManager2();
+  const auto& op1 = *taskManager1();
+  const auto& op2 = *taskManager2();
 
-        return op1.equals(op2);
-    }
+  return op1.equals(op2);
+}
 
 } // namespace ec

--- a/src/checker/dd/DDEquivalenceChecker.cpp
+++ b/src/checker/dd/DDEquivalenceChecker.cpp
@@ -1,6 +1,6 @@
 //
-// This file is part of MQT QCEC library which is released under the MIT license.
-// See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
 #include "checker/dd/DDEquivalenceChecker.hpp"
@@ -15,226 +15,263 @@
 
 namespace ec {
 
-    template<class DDType, class DDPackage>
-    DDEquivalenceChecker<DDType, DDPackage>::DDEquivalenceChecker(const qc::QuantumComputation& qc1, const qc::QuantumComputation& qc2, Configuration configuration) noexcept:
-        EquivalenceChecker(qc1, qc2, std::move(configuration)),
-        dd(std::make_unique<DDPackage>(nqubits)),
-        taskManager1(TaskManager<DDType, DDPackage>(qc1, dd)),
-        taskManager2(TaskManager<DDType, DDPackage>(qc2, dd)) {
+template <class DDType, class DDPackage>
+DDEquivalenceChecker<DDType, DDPackage>::DDEquivalenceChecker(
+    const qc::QuantumComputation& qc1, const qc::QuantumComputation& qc2,
+    Configuration configuration) noexcept
+    : EquivalenceChecker(qc1, qc2, std::move(configuration)),
+      dd(std::make_unique<DDPackage>(nqubits)),
+      taskManager1(TaskManager<DDType, DDPackage>(qc1, dd)),
+      taskManager2(TaskManager<DDType, DDPackage>(qc2, dd)) {}
+
+template <class DDType, class DDPackage>
+EquivalenceCriterion
+DDEquivalenceChecker<DDType, DDPackage>::equals(const DDType& e,
+                                                const DDType& f) {
+  // both node pointers being equivalent is the strongest indication that the
+  // two decision diagrams are equivalent
+  if (e.p == f.p) {
+    // whenever the top edge weights differ, both decision diagrams are only
+    // equivalent up to a global phase
+    if (!e.w.approximatelyEquals(f.w)) {
+      if constexpr (std::is_same_v<DDType, qc::MatrixDD>) {
+        return EquivalenceCriterion::EquivalentUpToGlobalPhase;
+      } else {
+        return EquivalenceCriterion::EquivalentUpToPhase;
+      }
+    }
+    return EquivalenceCriterion::Equivalent;
+  }
+
+  // in general, decision diagrams are canonic. This implies that if their top
+  // nodes differ, they are not equivalent. However, numerical instabilities
+  // might create a scenario where two nodes differ besides their underlying
+  // decision diagrams being extremely close (for some definition of `close`).
+  if constexpr (std::is_same_v<DDType, qc::MatrixDD>) {
+    // for matrices this can be resolved by calculating their Frobenius inner
+    // product trace(U V^-1) and comparing it to some threshold. in a similar
+    // fashion, we can simply compare U V^-1 with the identity, which results in
+    // a much simpler check that is not prone to overflow.
+    bool isClose{};
+    if (e.p->isIdentity()) {
+      isClose =
+          dd->isCloseToIdentity(f, configuration.functionality.traceThreshold);
+    } else if (f.p->isIdentity()) {
+      isClose =
+          dd->isCloseToIdentity(e, configuration.functionality.traceThreshold);
+    } else {
+      auto g = dd->multiply(e, dd->conjugateTranspose(f));
+      isClose =
+          dd->isCloseToIdentity(g, configuration.functionality.traceThreshold);
     }
 
-    template<class DDType, class DDPackage>
-    EquivalenceCriterion DDEquivalenceChecker<DDType, DDPackage>::equals(const DDType& e, const DDType& f) {
-        // both node pointers being equivalent is the strongest indication that the two decision diagrams are equivalent
-        if (e.p == f.p) {
-            // whenever the top edge weights differ, both decision diagrams are only equivalent up to a global phase
-            if (!e.w.approximatelyEquals(f.w)) {
-                if constexpr (std::is_same_v<DDType, qc::MatrixDD>) {
-                    return EquivalenceCriterion::EquivalentUpToGlobalPhase;
-                } else {
-                    return EquivalenceCriterion::EquivalentUpToPhase;
-                }
-            }
-            return EquivalenceCriterion::Equivalent;
-        }
+    if (isClose) {
+      // whenever the top edge weights differ, both decision diagrams are only
+      // equivalent up to a global phase
+      if (!e.w.approximatelyEquals(f.w)) {
+        return EquivalenceCriterion::EquivalentUpToGlobalPhase;
+      }
+      return EquivalenceCriterion::Equivalent;
+    }
+  } else {
+    // for vectors this is resolved by computing the inner product (or fidelity)
+    // between both decision diagrams and comparing it to some threshold
+    const auto innerProduct = dd->innerProduct(e, f);
 
-        // in general, decision diagrams are canonic. This implies that if their top nodes differ, they are not
-        // equivalent. However, numerical instabilities might create a scenario where two nodes differ besides
-        // their underlying decision diagrams being extremely close (for some definition of `close`).
-        if constexpr (std::is_same_v<DDType, qc::MatrixDD>) {
-            // for matrices this can be resolved by calculating their Frobenius inner product trace(U V^-1) and comparing it to some threshold.
-            // in a similar fashion, we can simply compare U V^-1 with the identity, which results in a much simpler check that is not prone to overflow.
-            bool isClose{};
-            if (e.p->isIdentity()) {
-                isClose = dd->isCloseToIdentity(f, configuration.functionality.traceThreshold);
-            } else if (f.p->isIdentity()) {
-                isClose = dd->isCloseToIdentity(e, configuration.functionality.traceThreshold);
-            } else {
-                auto g  = dd->multiply(e, dd->conjugateTranspose(f));
-                isClose = dd->isCloseToIdentity(g, configuration.functionality.traceThreshold);
-            }
-
-            if (isClose) {
-                // whenever the top edge weights differ, both decision diagrams are only equivalent up to a global phase
-                if (!e.w.approximatelyEquals(f.w)) {
-                    return EquivalenceCriterion::EquivalentUpToGlobalPhase;
-                }
-                return EquivalenceCriterion::Equivalent;
-            }
-        } else {
-            // for vectors this is resolved by computing the inner product (or fidelity) between both decision
-            // diagrams and comparing it to some threshold
-            const auto innerProduct = dd->innerProduct(e, f);
-
-            // whenever <e,f> ≃ 1, both decision diagrams should be considered equivalent
-            if (std::abs(innerProduct.r - 1.) < configuration.simulation.fidelityThreshold) {
-                return EquivalenceCriterion::Equivalent;
-            }
-
-            // whenever |<e,f>|^2 ≃ 1, both decision diagrams should be considered equivalent up to a phase
-            const auto fidelity = (innerProduct.r * innerProduct.r) + (innerProduct.i * innerProduct.i);
-            if (std::abs(fidelity - 1.0) < configuration.simulation.fidelityThreshold) {
-                return EquivalenceCriterion::EquivalentUpToPhase;
-            }
-        }
-
-        return EquivalenceCriterion::NotEquivalent;
+    // whenever <e,f> ≃ 1, both decision diagrams should be considered
+    // equivalent
+    if (std::abs(innerProduct.r - 1.) <
+        configuration.simulation.fidelityThreshold) {
+      return EquivalenceCriterion::Equivalent;
     }
 
-    template<class DDType, class DDPackage>
-    EquivalenceCriterion DDEquivalenceChecker<DDType, DDPackage>::run() {
-        const auto start = std::chrono::steady_clock::now();
-
-        // initialize the internal representation (initial state, initial matrix, etc.)
-        initialize();
-
-        if (isDone()) {
-            return equivalence;
-        }
-
-        // execute the equivalence checking scheme
-        execute();
-
-        if (isDone()) {
-            return equivalence;
-        }
-
-        // finish off both circuits
-        finish();
-
-        if (isDone()) {
-            return equivalence;
-        }
-
-        // postprocess the result
-        postprocess();
-
-        if (isDone()) {
-            return equivalence;
-        }
-
-        // check the equivalence
-        equivalence = checkEquivalence();
-
-        // determine maximum number of nodes used
-        if constexpr (std::is_same_v<DDType, qc::MatrixDD>) {
-            maxActiveNodes = dd->mUniqueTable.getMaxActiveNodes();
-        }
-
-        if constexpr (std::is_same_v<DDType, qc::VectorDD>) {
-            maxActiveNodes = dd->vUniqueTable.getMaxActiveNodes();
-        }
-
-        const auto end = std::chrono::steady_clock::now();
-        runtime += std::chrono::duration<double>(end - start).count();
-
-        return equivalence;
+    // whenever |<e,f>|^2 ≃ 1, both decision diagrams should be considered
+    // equivalent up to a phase
+    const auto fidelity =
+        (innerProduct.r * innerProduct.r) + (innerProduct.i * innerProduct.i);
+    if (std::abs(fidelity - 1.0) < configuration.simulation.fidelityThreshold) {
+      return EquivalenceCriterion::EquivalentUpToPhase;
     }
+  }
 
-    template<class DDType, class DDPackage>
-    void DDEquivalenceChecker<DDType, DDPackage>::initialize() {
-        initializeTask(taskManager1);
-        initializeTask(taskManager2);
+  return EquivalenceCriterion::NotEquivalent;
+}
+
+template <class DDType, class DDPackage>
+EquivalenceCriterion DDEquivalenceChecker<DDType, DDPackage>::run() {
+  const auto start = std::chrono::steady_clock::now();
+
+  // initialize the internal representation (initial state, initial matrix,
+  // etc.)
+  initialize();
+
+  if (isDone()) {
+    return equivalence;
+  }
+
+  // execute the equivalence checking scheme
+  execute();
+
+  if (isDone()) {
+    return equivalence;
+  }
+
+  // finish off both circuits
+  finish();
+
+  if (isDone()) {
+    return equivalence;
+  }
+
+  // postprocess the result
+  postprocess();
+
+  if (isDone()) {
+    return equivalence;
+  }
+
+  // check the equivalence
+  equivalence = checkEquivalence();
+
+  // determine maximum number of nodes used
+  if constexpr (std::is_same_v<DDType, qc::MatrixDD>) {
+    maxActiveNodes = dd->mUniqueTable.getMaxActiveNodes();
+  }
+
+  if constexpr (std::is_same_v<DDType, qc::VectorDD>) {
+    maxActiveNodes = dd->vUniqueTable.getMaxActiveNodes();
+  }
+
+  const auto end = std::chrono::steady_clock::now();
+  runtime += std::chrono::duration<double>(end - start).count();
+
+  return equivalence;
+}
+
+template <class DDType, class DDPackage>
+void DDEquivalenceChecker<DDType, DDPackage>::initialize() {
+  initializeTask(taskManager1);
+  initializeTask(taskManager2);
+}
+
+template <class DDType, class DDPackage>
+void DDEquivalenceChecker<DDType, DDPackage>::execute() {
+  while (!taskManager1.finished() && !taskManager2.finished() && !isDone()) {
+    // skip over any SWAP operations
+    taskManager1.applySwapOperations();
+    taskManager2.applySwapOperations();
+
+    if (!taskManager1.finished() && !taskManager2.finished()) {
+      // query application scheme on how to proceed
+      const auto [apply1, apply2] = (*applicationScheme)();
+
+      // advance both tasks correspondingly
+      if (isDone()) {
+        return;
+      }
+      taskManager1.advance(apply1);
+      if (isDone()) {
+        return;
+      }
+      taskManager2.advance(apply2);
     }
+  }
+}
 
-    template<class DDType, class DDPackage>
-    void DDEquivalenceChecker<DDType, DDPackage>::execute() {
-        while (!taskManager1.finished() && !taskManager2.finished() && !isDone()) {
-            // skip over any SWAP operations
-            taskManager1.applySwapOperations();
-            taskManager2.applySwapOperations();
+template <class DDType, class DDPackage>
+void DDEquivalenceChecker<DDType, DDPackage>::finish() {
+  taskManager1.finish();
+  if (isDone()) {
+    return;
+  }
+  taskManager2.finish();
+}
 
-            if (!taskManager1.finished() && !taskManager2.finished()) {
-                // query application scheme on how to proceed
-                const auto [apply1, apply2] = (*applicationScheme)();
+template <class DDType, class DDPackage>
+void DDEquivalenceChecker<DDType, DDPackage>::postprocessTask(
+    TaskManager<DDType, DDPackage>& task) {
+  // ensure that the permutation that was tracked throughout the circuit matches
+  // the expected output permutation
+  task.changePermutation();
+  if (isDone()) {
+    return;
+  }
+  // eliminate the superfluous contributions of ancillary qubits (this only has
+  // an effect on matrices)
+  task.reduceAncillae();
+  if (isDone()) {
+    return;
+  }
+  // sum up the contributions of garbage qubits
+  task.reduceGarbage();
+}
 
-                // advance both tasks correspondingly
-                if (isDone()) {
-                    return;
-                }
-                taskManager1.advance(apply1);
-                if (isDone()) {
-                    return;
-                }
-                taskManager2.advance(apply2);
-            }
-        }
+template <class DDType, class DDPackage>
+void DDEquivalenceChecker<DDType, DDPackage>::postprocess() {
+  postprocessTask(taskManager1);
+  if (isDone()) {
+    return;
+  }
+  postprocessTask(taskManager2);
+}
+
+template <class DDType, class DDPackage>
+EquivalenceCriterion
+DDEquivalenceChecker<DDType, DDPackage>::checkEquivalence() {
+  return equals(taskManager1.getInternalState(),
+                taskManager2.getInternalState());
+}
+
+template <class DDType, class DDPackage>
+void DDEquivalenceChecker<DDType, DDPackage>::initializeApplicationScheme(
+    const ApplicationSchemeType scheme) {
+  switch (scheme) {
+  case ApplicationSchemeType::Sequential:
+    applicationScheme =
+        std::make_unique<SequentialApplicationScheme<DDType, DDPackage>>(
+            taskManager1, taskManager2);
+    break;
+  case ApplicationSchemeType::OneToOne:
+    applicationScheme =
+        std::make_unique<OneToOneApplicationScheme<DDType, DDPackage>>(
+            taskManager1, taskManager2);
+    break;
+  case ApplicationSchemeType::Lookahead:
+    if constexpr (std::is_same_v<DDType, qc::MatrixDD>) {
+      applicationScheme =
+          std::make_unique<LookaheadApplicationScheme<DDPackage>>(taskManager1,
+                                                                  taskManager2);
+    } else {
+      throw std::invalid_argument(
+          "Lookahead application scheme can only be used for matrices.");
     }
-
-    template<class DDType, class DDPackage>
-    void DDEquivalenceChecker<DDType, DDPackage>::finish() {
-        taskManager1.finish();
-        if (isDone()) {
-            return;
-        }
-        taskManager2.finish();
+    break;
+  case ApplicationSchemeType::GateCost:
+    if (!configuration.application.profile.empty()) {
+      applicationScheme =
+          std::make_unique<GateCostApplicationScheme<DDType, DDPackage>>(
+              taskManager1, taskManager2, configuration.application.profile);
+    } else {
+      applicationScheme =
+          std::make_unique<GateCostApplicationScheme<DDType, DDPackage>>(
+              taskManager1, taskManager2,
+              configuration.application.costFunction);
     }
+    break;
+  default:
+    applicationScheme =
+        std::make_unique<ProportionalApplicationScheme<DDType, DDPackage>>(
+            taskManager1, taskManager2);
+    break;
+  }
+}
 
-    template<class DDType, class DDPackage>
-    void DDEquivalenceChecker<DDType, DDPackage>::postprocessTask(TaskManager<DDType, DDPackage>& task) {
-        // ensure that the permutation that was tracked throughout the circuit matches the expected output permutation
-        task.changePermutation();
-        if (isDone()) {
-            return;
-        }
-        // eliminate the superfluous contributions of ancillary qubits (this only has an effect on matrices)
-        task.reduceAncillae();
-        if (isDone()) {
-            return;
-        }
-        // sum up the contributions of garbage qubits
-        task.reduceGarbage();
-    }
-
-    template<class DDType, class DDPackage>
-    void DDEquivalenceChecker<DDType, DDPackage>::postprocess() {
-        postprocessTask(taskManager1);
-        if (isDone()) {
-            return;
-        }
-        postprocessTask(taskManager2);
-    }
-
-    template<class DDType, class DDPackage>
-    EquivalenceCriterion DDEquivalenceChecker<DDType, DDPackage>::checkEquivalence() {
-        return equals(taskManager1.getInternalState(), taskManager2.getInternalState());
-    }
-
-    template<class DDType, class DDPackage>
-    void DDEquivalenceChecker<DDType, DDPackage>::initializeApplicationScheme(const ApplicationSchemeType scheme) {
-        switch (scheme) {
-            case ApplicationSchemeType::Sequential:
-                applicationScheme = std::make_unique<SequentialApplicationScheme<DDType, DDPackage>>(taskManager1, taskManager2);
-                break;
-            case ApplicationSchemeType::OneToOne:
-                applicationScheme = std::make_unique<OneToOneApplicationScheme<DDType, DDPackage>>(taskManager1, taskManager2);
-                break;
-            case ApplicationSchemeType::Lookahead:
-                if constexpr (std::is_same_v<DDType, qc::MatrixDD>) {
-                    applicationScheme = std::make_unique<LookaheadApplicationScheme<DDPackage>>(taskManager1, taskManager2);
-                } else {
-                    throw std::invalid_argument("Lookahead application scheme can only be used for matrices.");
-                }
-                break;
-            case ApplicationSchemeType::GateCost:
-                if (!configuration.application.profile.empty()) {
-                    applicationScheme = std::make_unique<GateCostApplicationScheme<DDType, DDPackage>>(taskManager1, taskManager2, configuration.application.profile);
-                } else {
-                    applicationScheme = std::make_unique<GateCostApplicationScheme<DDType, DDPackage>>(taskManager1, taskManager2, configuration.application.costFunction);
-                }
-                break;
-            default:
-                applicationScheme = std::make_unique<ProportionalApplicationScheme<DDType, DDPackage>>(taskManager1, taskManager2);
-                break;
-        }
-    }
-
-    template class DDEquivalenceChecker<qc::VectorDD, dd::Package<>>;
-    template class DDEquivalenceChecker<qc::MatrixDD, dd::Package<>>;
-    template class DDEquivalenceChecker<qc::VectorDD, SimulationDDPackage>;
-    template class DDEquivalenceChecker<qc::MatrixDD, SimulationDDPackage>;
-    template class DDEquivalenceChecker<qc::VectorDD, ConstructionDDPackage>;
-    template class DDEquivalenceChecker<qc::MatrixDD, ConstructionDDPackage>;
-    template class DDEquivalenceChecker<qc::VectorDD, AlternatingDDPackage>;
-    template class DDEquivalenceChecker<qc::MatrixDD, AlternatingDDPackage>;
+template class DDEquivalenceChecker<qc::VectorDD, dd::Package<>>;
+template class DDEquivalenceChecker<qc::MatrixDD, dd::Package<>>;
+template class DDEquivalenceChecker<qc::VectorDD, SimulationDDPackage>;
+template class DDEquivalenceChecker<qc::MatrixDD, SimulationDDPackage>;
+template class DDEquivalenceChecker<qc::VectorDD, ConstructionDDPackage>;
+template class DDEquivalenceChecker<qc::MatrixDD, ConstructionDDPackage>;
+template class DDEquivalenceChecker<qc::VectorDD, AlternatingDDPackage>;
+template class DDEquivalenceChecker<qc::MatrixDD, AlternatingDDPackage>;
 } // namespace ec

--- a/src/checker/dd/DDSimulationChecker.cpp
+++ b/src/checker/dd/DDSimulationChecker.cpp
@@ -1,35 +1,39 @@
 //
-// This file is part of MQT QCEC library which is released under the MIT license.
-// See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
 #include "checker/dd/DDSimulationChecker.hpp"
 
 namespace ec {
-    DDSimulationChecker::DDSimulationChecker(const qc::QuantumComputation& qc1, const qc::QuantumComputation& qc2, Configuration configuration) noexcept:
-        DDEquivalenceChecker(qc1, qc2, std::move(configuration)) {
-        initialState = dd->makeZeroState(nqubits);
-        initializeApplicationScheme(this->configuration.application.simulationScheme);
-    }
+DDSimulationChecker::DDSimulationChecker(const qc::QuantumComputation& qc1,
+                                         const qc::QuantumComputation& qc2,
+                                         Configuration configuration) noexcept
+    : DDEquivalenceChecker(qc1, qc2, std::move(configuration)) {
+  initialState = dd->makeZeroState(nqubits);
+  initializeApplicationScheme(this->configuration.application.simulationScheme);
+}
 
-    void DDSimulationChecker::initializeTask(TaskManager<qc::VectorDD, SimulationDDPackage>& taskManager) {
-        taskManager.setInternalState(initialState);
-        taskManager.incRef();
-    }
+void DDSimulationChecker::initializeTask(
+    TaskManager<qc::VectorDD, SimulationDDPackage>& taskManager) {
+  taskManager.setInternalState(initialState);
+  taskManager.incRef();
+}
 
-    EquivalenceCriterion DDSimulationChecker::checkEquivalence() {
-        equivalence = DDEquivalenceChecker::checkEquivalence();
+EquivalenceCriterion DDSimulationChecker::checkEquivalence() {
+  equivalence = DDEquivalenceChecker::checkEquivalence();
 
-        // adjust reference counts to facilitate reuse of the simulation checker
-        taskManager1.decRef();
-        taskManager2.decRef();
+  // adjust reference counts to facilitate reuse of the simulation checker
+  taskManager1.decRef();
+  taskManager2.decRef();
 
-        return equivalence;
-    }
+  return equivalence;
+}
 
-    void DDSimulationChecker::setRandomInitialState(StateGenerator& generator) {
-        const dd::QubitCount nancillary = nqubits - qc1.getNqubitsWithoutAncillae();
-        initialState                    = generator.generateRandomState(dd, nqubits, nancillary, configuration.simulation.stateType);
-    }
+void DDSimulationChecker::setRandomInitialState(StateGenerator& generator) {
+  const dd::QubitCount nancillary = nqubits - qc1.getNqubitsWithoutAncillae();
+  initialState                    = generator.generateRandomState(
+      dd, nqubits, nancillary, configuration.simulation.stateType);
+}
 
 } // namespace ec

--- a/src/checker/dd/DDSimulationChecker.cpp
+++ b/src/checker/dd/DDSimulationChecker.cpp
@@ -8,10 +8,10 @@
 namespace ec {
 DDSimulationChecker::DDSimulationChecker(const qc::QuantumComputation& qc1,
                                          const qc::QuantumComputation& qc2,
-                                         Configuration configuration) noexcept
-    : DDEquivalenceChecker(qc1, qc2, std::move(configuration)) {
+                                         Configuration config) noexcept
+    : DDEquivalenceChecker(qc1, qc2, std::move(config)) {
   initialState = dd->makeZeroState(nqubits);
-  initializeApplicationScheme(this->configuration.application.simulationScheme);
+  initializeApplicationScheme(configuration.application.simulationScheme);
 }
 
 void DDSimulationChecker::initializeTask(

--- a/src/checker/zx/ZXChecker.cpp
+++ b/src/checker/zx/ZXChecker.cpp
@@ -1,3 +1,8 @@
+//
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
+//
+
 #include "checker/zx/ZXChecker.hpp"
 
 #include "Definitions.hpp"
@@ -8,248 +13,255 @@
 #include "zx/FunctionalityConstruction.hpp"
 
 #include <chrono>
-#include <cstddef>
-#include <numeric>
 #include <optional>
 
 namespace ec {
-    ZXEquivalenceChecker::ZXEquivalenceChecker(const qc::QuantumComputation& qc1, const qc::QuantumComputation& qc2, Configuration configuration) noexcept:
-        EquivalenceChecker(qc1, qc2, std::move(configuration)), miter(zx::FunctionalityConstruction::buildFunctionality(&qc1)), tolerance(configuration.functionality.traceThreshold) {
-        zx::ZXDiagram dPrime = zx::FunctionalityConstruction::buildFunctionality(&qc2);
+ZXEquivalenceChecker::ZXEquivalenceChecker(const qc::QuantumComputation& qc1,
+                                           const qc::QuantumComputation& qc2,
+                                           Configuration configuration) noexcept
+    : EquivalenceChecker(qc1, qc2, std::move(configuration)),
+      miter(zx::FunctionalityConstruction::buildFunctionality(&qc1)),
+      tolerance(configuration.functionality.traceThreshold) {
+  zx::ZXDiagram dPrime =
+      zx::FunctionalityConstruction::buildFunctionality(&qc2);
 
-        if ((qc1.getNancillae() != 0) || (qc2.getNancillae() != 0)) {
-            ancilla = true;
-        }
+  if ((qc1.getNancillae() != 0) || (qc2.getNancillae() != 0)) {
+    ancilla = true;
+  }
 
-        const auto& p1 = invertPermutations(qc1);
-        const auto& p2 = invertPermutations(qc2);
+  const auto& p1 = invertPermutations(qc1);
+  const auto& p2 = invertPermutations(qc2);
 
-        // fix ancillaries to |0>
-        const auto nQubitsWithoutAncillae = qc1.getNqubitsWithoutAncillae();
-        for (auto anc = static_cast<dd::Qubit>(qc1.getNqubits() - 1); anc >= nQubitsWithoutAncillae; --anc) {
-            miter.makeAncilla(anc, p1.at(anc));
-            dPrime.makeAncilla(anc, p2.at(anc));
-        }
-        miter.invert();
-        miter.concat(dPrime);
+  // fix ancillaries to |0>
+  const auto nQubitsWithoutAncillae = qc1.getNqubitsWithoutAncillae();
+  for (auto anc = static_cast<dd::Qubit>(qc1.getNqubits() - 1);
+       anc >= nQubitsWithoutAncillae; --anc) {
+    miter.makeAncilla(anc, p1.at(anc));
+    dPrime.makeAncilla(anc, p2.at(anc));
+  }
+  miter.invert();
+  miter.concat(dPrime);
+}
+
+EquivalenceCriterion ZXEquivalenceChecker::run() {
+  const auto start = std::chrono::steady_clock::now();
+
+  fullReduceApproximate();
+
+  bool equivalent = true;
+
+  if (miter.getNEdges() == miter.getNQubits()) {
+    const auto& p1 = invert(invertPermutations(qc1));
+    const auto& p2 = invert(invertPermutations(qc2));
+
+    const auto nQubits = miter.getNQubits();
+    for (std::size_t i = 0; i < nQubits; ++i) {
+      const auto& in  = miter.getInput(i);
+      const auto& out = miter.incidentEdge(in, 0).to;
+
+      if (p1.at(static_cast<dd::Qubit>(miter.getVData(in).value().qubit)) !=
+          p2.at(static_cast<dd::Qubit>(miter.getVData(out).value().qubit))) {
+        equivalent = false;
+        break;
+      }
+    }
+  } else {
+    equivalent = false;
+  }
+
+  const auto end = std::chrono::steady_clock::now();
+  runtime += std::chrono::duration<double>(end - start).count();
+
+  // non-equivalence might be due to incorrect assumption about the state of
+  // ancillaries or the check was aborted prematurely, so no information can be
+  // given
+  if ((!equivalent && ancilla) || isDone()) {
+    equivalence = EquivalenceCriterion::NoInformation;
+  } else {
+    if (equivalent) {
+      equivalence = EquivalenceCriterion::EquivalentUpToGlobalPhase;
+    } else {
+      equivalence = EquivalenceCriterion::ProbablyNotEquivalent;
+    }
+  }
+  return equivalence;
+}
+
+qc::Permutation invert(const qc::Permutation& p) {
+  qc::Permutation pInv{};
+  for (const auto [v, w] : p) {
+    pInv[w] = v;
+  }
+  return pInv;
+}
+qc::Permutation concat(const qc::Permutation& p1,
+                       const qc::Permutation& p2) { // p2 after p1
+  qc::Permutation pComb{};
+
+  for (const auto [v, w] : p1) {
+    if (p2.find(w) != p2.end()) {
+      pComb[v] = p2.at(w);
+    }
+  }
+  return pComb;
+}
+
+qc::Permutation complete(const qc::Permutation& p, const dd::QubitCount n) {
+  qc::Permutation pComp = p;
+
+  std::vector<bool> mappedTo(n, false);
+  std::vector<bool> mappedFrom(n, false);
+  for (const auto [k, v] : p) {
+    mappedFrom[k] = true;
+    mappedTo[v]   = true;
+  }
+
+  // Try to map identity
+  for (dd::Qubit i = 0; i < n; ++i) {
+    if (mappedFrom[i] || mappedTo[i]) {
+      continue;
     }
 
-    EquivalenceCriterion ZXEquivalenceChecker::run() {
-        const auto start = std::chrono::steady_clock::now();
+    pComp[i]      = i;
+    mappedFrom[i] = true;
+    mappedTo[i]   = true;
+  }
 
-        fullReduceApproximate();
-
-        bool equivalent = true;
-
-        if (miter.getNEdges() == miter.getNQubits()) {
-            const auto& p1 = invert(invertPermutations(qc1));
-            const auto& p2 = invert(invertPermutations(qc2));
-
-            const auto nQubits = miter.getNQubits();
-            for (std::size_t i = 0; i < nQubits; ++i) {
-                const auto& in  = miter.getInput(i);
-                const auto& out = miter.incidentEdge(in, 0).to;
-
-                if (p1.at(static_cast<dd::Qubit>(miter.getVData(in).value().qubit)) != p2.at(static_cast<dd::Qubit>(miter.getVData(out).value().qubit))) {
-                    equivalent = false;
-                    break;
-                }
-            }
-        } else {
-            equivalent = false;
-        }
-
-        const auto end = std::chrono::steady_clock::now();
-        runtime += std::chrono::duration<double>(end - start).count();
-
-        // non-equivalence might be due to incorrect assumption about the state of ancillaries or the check was aborted prematurely, so no information can be given
-        if ((!equivalent && ancilla) || isDone()) {
-            equivalence = EquivalenceCriterion::NoInformation;
-        } else {
-            if (equivalent) {
-                equivalence = EquivalenceCriterion::EquivalentUpToGlobalPhase;
-            } else {
-                equivalence = EquivalenceCriterion::ProbablyNotEquivalent;
-            }
-        }
-        return equivalence;
+  // Try to map inverse
+  for (dd::Qubit i = 0; i < n; ++i) {
+    if (mappedFrom[i]) {
+      continue;
+    }
+    std::optional<dd::Qubit> j;
+    for (const auto [k, v] : p) {
+      if (v == i) {
+        j = k;
+        break;
+      }
     }
 
-    qc::Permutation invert(const qc::Permutation& p) {
-        qc::Permutation pInv{};
-        for (const auto [v, w]: p) {
-            pInv[w] = v;
-        }
-        return pInv;
-    }
-    qc::Permutation concat(const qc::Permutation& p1, const qc::Permutation& p2) { // p2 after p1
-        qc::Permutation pComb{};
-
-        for (const auto [v, w]: p1) {
-            if (p2.find(w) != p2.end()) {
-                pComb[v] = p2.at(w);
-            }
-        }
-        return pComb;
+    if (mappedTo[j.value()]) {
+      continue;
     }
 
-    qc::Permutation complete(const qc::Permutation& p, const dd::QubitCount n) {
-        qc::Permutation pComp = p;
+    pComp[i]            = j.value();
+    mappedFrom[i]       = true;
+    mappedTo[j.value()] = true;
+  }
 
-        std::vector<bool> mappedTo(n, false);
-        std::vector<bool> mappedFrom(n, false);
-        for (const auto [k, v]: p) {
-            mappedFrom[k] = true;
-            mappedTo[v]   = true;
-        }
+  // Map rest greedily
 
-        // Try to map identity
-        for (dd::Qubit i = 0; i < n; ++i) {
-            if (mappedFrom[i] || mappedTo[i]) {
-                continue;
-            }
-
-            pComp[i]      = i;
-            mappedFrom[i] = true;
-            mappedTo[i]   = true;
-        }
-
-        // Try to map inverse
-        for (dd::Qubit i = 0; i < n; ++i) {
-            if (mappedFrom[i]) {
-                continue;
-            }
-            std::optional<dd::Qubit> j;
-            for (const auto [k, v]: p) {
-                if (v == i) {
-                    j = k;
-                    break;
-                }
-            }
-
-            if (mappedTo[j.value()]) {
-                continue;
-            }
-
-            pComp[i]            = j.value();
-            mappedFrom[i]       = true;
-            mappedTo[j.value()] = true;
-        }
-
-        // Map rest greedily
-
-        for (dd::Qubit i = 0; i < n; ++i) {
-            if (mappedFrom[i]) {
-                continue;
-            }
-
-            for (dd::Qubit j = 0; j < n; ++j) {
-                if (!mappedTo[j]) {
-                    pComp[i]    = j;
-                    mappedTo[j] = true;
-                    break;
-                }
-            }
-        }
-        return pComp;
+  for (dd::Qubit i = 0; i < n; ++i) {
+    if (mappedFrom[i]) {
+      continue;
     }
 
-    qc::Permutation invertPermutations(const qc::QuantumComputation& qc) {
-        return concat(
-            invert(complete(qc.outputPermutation, qc.getNqubits())),
-            complete(qc.initialLayout, qc.getNqubits()));
+    for (dd::Qubit j = 0; j < n; ++j) {
+      if (!mappedTo[j]) {
+        pComp[i]    = j;
+        mappedTo[j] = true;
+        break;
+      }
     }
+  }
+  return pComp;
+}
 
-    std::size_t ZXEquivalenceChecker::fullReduceApproximate() {
-        auto        nSimplifications = fullReduce();
-        std::size_t newSimps{};
-        do {
-            miter.approximateCliffords(tolerance);
-            newSimps = fullReduce();
-            nSimplifications += newSimps;
-        } while (!isDone() && (newSimps > 0));
-        return nSimplifications;
+qc::Permutation invertPermutations(const qc::QuantumComputation& qc) {
+  return concat(invert(complete(qc.outputPermutation, qc.getNqubits())),
+                complete(qc.initialLayout, qc.getNqubits()));
+}
+
+std::size_t ZXEquivalenceChecker::fullReduceApproximate() {
+  auto        nSimplifications = fullReduce();
+  std::size_t newSimps{};
+  do {
+    miter.approximateCliffords(tolerance);
+    newSimps = fullReduce();
+    nSimplifications += newSimps;
+  } while (!isDone() && (newSimps > 0));
+  return nSimplifications;
+}
+
+std::size_t ZXEquivalenceChecker::fullReduce() {
+  if (!isDone()) {
+    miter.toGraphlike();
+  }
+  interiorCliffordSimp();
+
+  bool        newMatches       = true;
+  std::size_t nSimplifications = 0;
+  while (!isDone() && newMatches) {
+    newMatches = false;
+    cliffordSimp();
+    const auto nGadget = gadgetSimp();
+    interiorCliffordSimp();
+    const auto nPivot = pivotGadgetSimp();
+    if ((nGadget + nPivot) != 0) {
+      newMatches = true;
+      ++nSimplifications;
     }
+  }
+  if (!isDone()) {
+    miter.removeDisconnectedSpiders();
+  }
 
-    std::size_t ZXEquivalenceChecker::fullReduce() {
-        if (!isDone()) {
-            miter.toGraphlike();
-        }
-        interiorCliffordSimp();
+  return nSimplifications;
+}
 
-        bool        newMatches       = true;
-        std::size_t nSimplifications = 0;
-        while (!isDone() && newMatches) {
-            newMatches = false;
-            cliffordSimp();
-            const auto nGadget = gadgetSimp();
-            interiorCliffordSimp();
-            const auto nPivot = pivotGadgetSimp();
-            if ((nGadget + nPivot) != 0) {
-                newMatches = true;
-                ++nSimplifications;
-            }
-        }
-        if (!isDone()) {
-            miter.removeDisconnectedSpiders();
-        }
+std::size_t ZXEquivalenceChecker::gadgetSimp() {
+  std::size_t nSimplifications = 0;
+  bool        newMatches       = true;
 
-        return nSimplifications;
+  while (!isDone() && newMatches) {
+    newMatches = false;
+    for (const auto& [v, _] : miter.getVertices()) {
+      if (miter.isDeleted(v)) {
+        continue;
+      }
+
+      if (!isDone() && checkAndFuseGadget(miter, v)) {
+        newMatches = true;
+        ++nSimplifications;
+      }
     }
+  }
+  return nSimplifications;
+}
 
-    std::size_t ZXEquivalenceChecker::gadgetSimp() {
-        std::size_t nSimplifications = 0;
-        bool        newMatches       = true;
+std::size_t ZXEquivalenceChecker::interiorCliffordSimp() {
+  spiderSimp();
 
-        while (!isDone() && newMatches) {
-            newMatches = false;
-            for (const auto& [v, _]: miter.getVertices()) {
-                if (miter.isDeleted(v)) {
-                    continue;
-                }
+  bool        newMatches       = true;
+  std::size_t nSimplifications = 0;
+  while (!isDone() && newMatches) {
+    newMatches            = false;
+    const auto nId        = idSimp();
+    const auto nSpider    = spiderSimp();
+    const auto nPivot     = pivotPauliSimp();
+    const auto nLocalComp = localCompSimp();
 
-                if (!isDone() && checkAndFuseGadget(miter, v)) {
-                    newMatches = true;
-                    ++nSimplifications;
-                }
-            }
-        }
-        return nSimplifications;
+    if ((nId + nSpider + nPivot + nLocalComp) != 0) {
+      newMatches = true;
+      ++nSimplifications;
     }
+  }
+  return nSimplifications;
+}
 
-    std::size_t ZXEquivalenceChecker::interiorCliffordSimp() {
-        spiderSimp();
-
-        bool        newMatches       = true;
-        std::size_t nSimplifications = 0;
-        while (!isDone() && newMatches) {
-            newMatches            = false;
-            const auto nId        = idSimp();
-            const auto nSpider    = spiderSimp();
-            const auto nPivot     = pivotPauliSimp();
-            const auto nLocalComp = localCompSimp();
-
-            if ((nId + nSpider + nPivot + nLocalComp) != 0) {
-                newMatches = true;
-                ++nSimplifications;
-            }
-        }
-        return nSimplifications;
+std::size_t ZXEquivalenceChecker::cliffordSimp() {
+  bool        newMatches       = true;
+  std::size_t nSimplifications = 0;
+  while (!isDone() && newMatches) {
+    newMatches           = false;
+    const auto nClifford = interiorCliffordSimp();
+    const auto nPivot    = pivotSimp();
+    if ((nClifford + nPivot) != 0) {
+      newMatches = true;
+      ++nSimplifications;
     }
-
-    std::size_t ZXEquivalenceChecker::cliffordSimp() {
-        bool        newMatches       = true;
-        std::size_t nSimplifications = 0;
-        while (!isDone() && newMatches) {
-            newMatches           = false;
-            const auto nClifford = interiorCliffordSimp();
-            const auto nPivot    = pivotSimp();
-            if ((nClifford + nPivot) != 0) {
-                newMatches = true;
-                ++nSimplifications;
-            }
-        }
-        return nSimplifications;
-    }
+  }
+  return nSimplifications;
+}
 
 } // namespace ec

--- a/test/legacy/test_compilationflow.cpp
+++ b/test/legacy/test_compilationflow.cpp
@@ -1,6 +1,6 @@
 //
-// This file is part of MQT QCEC library which is released under the MIT license.
-// See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
 #include "EquivalenceCheckingManager.hpp"
@@ -9,69 +9,56 @@
 #include <functional>
 #include <string>
 
-class CompilationFlowTest: public testing::TestWithParam<std::string> {
+class CompilationFlowTest : public testing::TestWithParam<std::string> {
 protected:
-    qc::QuantumComputation qcOriginal;
-    qc::QuantumComputation qcTranspiled;
+  qc::QuantumComputation qcOriginal;
+  qc::QuantumComputation qcTranspiled;
 
-    std::string testOriginalDir   = "./circuits/original/";
-    std::string testTranspiledDir = "./circuits/transpiled/";
+  std::string testOriginalDir   = "./circuits/original/";
+  std::string testTranspiledDir = "./circuits/transpiled/";
 
-    ec::Configuration configuration{};
+  ec::Configuration configuration{};
 
-    void SetUp() override {
-        qcOriginal.import(testOriginalDir + GetParam() + ".real");
-        qcTranspiled.import(testTranspiledDir + GetParam() + "_transpiled.qasm");
+  void SetUp() override {
+    qcOriginal.import(testOriginalDir + GetParam() + ".real");
+    qcTranspiled.import(testTranspiledDir + GetParam() + "_transpiled.qasm");
 
-        configuration.execution.runAlternatingChecker  = true;
-        configuration.execution.runConstructionChecker = false;
-        configuration.execution.runSimulationChecker   = false;
+    configuration.execution.runAlternatingChecker  = true;
+    configuration.execution.runConstructionChecker = false;
+    configuration.execution.runSimulationChecker   = false;
 
-        configuration.application.alternatingScheme = ec::ApplicationSchemeType::GateCost;
-        configuration.application.costFunction      = ec::LegacyIBMCostFunction;
-    }
+    configuration.application.alternatingScheme =
+        ec::ApplicationSchemeType::GateCost;
+    configuration.application.costFunction = ec::LegacyIBMCostFunction;
+  }
 };
 
-INSTANTIATE_TEST_SUITE_P(CompilationFlowTest, CompilationFlowTest,
-                         testing::Values(
-                             "dk27_225",
-                             "pcler8_248",
-                             "5xp1_194",
-                             "alu1_198",
-                             "mlp4_245",
-                             "dk17_224",
-                             "add6_196",
-                             "C7552_205",
-                             "cu_219",
-                             "example2_231",
-                             "c2_181",
-                             "rd73_312",
-                             "cm150a_210",
-                             "cm163a_213",
-                             "c2_182",
-                             "sym9_317",
-                             "mod5adder_306",
-                             "rd84_313",
-                             "cm151a_211",
-                             "apla_203"),
-                         [](const testing::TestParamInfo<CompilationFlowTest::ParamType>& info) {
-							 auto s = info.param;
-							 std::replace( s.begin(), s.end(), '-', '_');
-	                         return s; });
+INSTANTIATE_TEST_SUITE_P(
+    CompilationFlowTest, CompilationFlowTest,
+    testing::Values("dk27_225", "pcler8_248", "5xp1_194", "alu1_198",
+                    "mlp4_245", "dk17_224", "add6_196", "C7552_205", "cu_219",
+                    "example2_231", "c2_181", "rd73_312", "cm150a_210",
+                    "cm163a_213", "c2_182", "sym9_317", "mod5adder_306",
+                    "rd84_313", "cm151a_211", "apla_203"),
+    [](const testing::TestParamInfo<CompilationFlowTest::ParamType>& info) {
+      auto s = info.param;
+      std::replace(s.begin(), s.end(), '-', '_');
+      return s;
+    });
 
 TEST_P(CompilationFlowTest, EquivalenceCompilationFlow) {
-    ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, configuration);
-    ecm.run();
-    std::cout << ecm.toString() << std::endl;
-    EXPECT_TRUE(ecm.getResults().consideredEquivalent());
+  ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, configuration);
+  ecm.run();
+  std::cout << ecm.toString() << std::endl;
+  EXPECT_TRUE(ecm.getResults().consideredEquivalent());
 }
 
 TEST_P(CompilationFlowTest, EquivalenceCompilationFlowParallel) {
-    configuration.execution.runSimulationChecker = true;
-    configuration.execution.parallel             = true;
+  configuration.execution.runSimulationChecker = true;
+  configuration.execution.parallel             = true;
 
-    ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, configuration);
-    ecm.run();
-    std::cout << ecm.toString() << std::endl;
-    EXPECT_TRUE(ecm.getResults().consideredEquivalent());
+  ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, configuration);
+  ecm.run();
+  std::cout << ecm.toString() << std::endl;
+  EXPECT_TRUE(ecm.getResults().consideredEquivalent());
 }

--- a/test/legacy/test_functionality.cpp
+++ b/test/legacy/test_functionality.cpp
@@ -1,6 +1,6 @@
 //
-// This file is part of MQT QCEC library which is released under the MIT license.
-// See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
 #include "EquivalenceCheckingManager.hpp"
@@ -9,189 +9,195 @@
 #include <iostream>
 #include <string>
 
-class FunctionalityTest: public testing::TestWithParam<std::string> {
+class FunctionalityTest : public testing::TestWithParam<std::string> {
 protected:
-    qc::QuantumComputation qcOriginal;
-    qc::QuantumComputation qcAlternative;
-    ec::Configuration      config{};
+  qc::QuantumComputation qcOriginal;
+  qc::QuantumComputation qcAlternative;
+  ec::Configuration      config{};
 
-    std::string testOriginal       = "./circuits/test/test.real";
-    std::string testAlternativeDir = "./circuits/test/";
+  std::string testOriginal       = "./circuits/test/test.real";
+  std::string testAlternativeDir = "./circuits/test/";
 
-    void SetUp() override {
-        qcOriginal.import(testOriginal);
+  void SetUp() override {
+    qcOriginal.import(testOriginal);
 
-        config.execution.parallel               = false;
-        config.execution.runConstructionChecker = false;
-        config.execution.runAlternatingChecker  = false;
-        config.execution.runSimulationChecker   = false;
-        config.simulation.maxSims               = 16;
-        config.application.constructionScheme   = ec::ApplicationSchemeType::Sequential;
-        config.application.simulationScheme     = ec::ApplicationSchemeType::Sequential;
-        config.application.alternatingScheme    = ec::ApplicationSchemeType::Sequential;
-    }
+    config.execution.parallel               = false;
+    config.execution.runConstructionChecker = false;
+    config.execution.runAlternatingChecker  = false;
+    config.execution.runSimulationChecker   = false;
+    config.simulation.maxSims               = 16;
+    config.application.constructionScheme =
+        ec::ApplicationSchemeType::Sequential;
+    config.application.simulationScheme = ec::ApplicationSchemeType::Sequential;
+    config.application.alternatingScheme =
+        ec::ApplicationSchemeType::Sequential;
+  }
 };
 
-INSTANTIATE_TEST_SUITE_P(TestCircuits, FunctionalityTest,
-                         testing::Values(
-                             "inputperm", "ancilla", "ancilla_inputperm", "swap",
-                             "outputperm", "ancilla_inputperm_outputperm",
-                             "optimizedswap", "ancilla_inputperm_outputperm_optimizedswap",
-                             "ancilla_inputperm_outputperm_optimizedswap2"),
-                         [](const testing::TestParamInfo<FunctionalityTest::ParamType>& info) {
-			                 std::stringstream ss{};
-			                 ss << info.param;
-			                 return ss.str(); });
+INSTANTIATE_TEST_SUITE_P(
+    TestCircuits, FunctionalityTest,
+    testing::Values("inputperm", "ancilla", "ancilla_inputperm", "swap",
+                    "outputperm", "ancilla_inputperm_outputperm",
+                    "optimizedswap",
+                    "ancilla_inputperm_outputperm_optimizedswap",
+                    "ancilla_inputperm_outputperm_optimizedswap2"),
+    [](const testing::TestParamInfo<FunctionalityTest::ParamType>& info) {
+      std::stringstream ss{};
+      ss << info.param;
+      return ss.str();
+    });
 
 TEST_P(FunctionalityTest, Reference) {
-    qcAlternative.import(testAlternativeDir + "test_" + GetParam() + ".qasm");
+  qcAlternative.import(testAlternativeDir + "test_" + GetParam() + ".qasm");
 
-    config.execution.runConstructionChecker = true;
+  config.execution.runConstructionChecker = true;
 
-    ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
-    ecm.run();
-    std::cout << ecm << std::endl;
-    EXPECT_TRUE(ecm.getResults().consideredEquivalent());
+  ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
+  ecm.run();
+  std::cout << ecm << std::endl;
+  EXPECT_TRUE(ecm.getResults().consideredEquivalent());
 }
 
 TEST_P(FunctionalityTest, Proportional) {
-    qcAlternative.import(testAlternativeDir + "test_" + GetParam() + ".qasm");
+  qcAlternative.import(testAlternativeDir + "test_" + GetParam() + ".qasm");
 
-    config.execution.runAlternatingChecker = true;
-    config.application.alternatingScheme   = ec::ApplicationSchemeType::Proportional;
+  config.execution.runAlternatingChecker = true;
+  config.application.alternatingScheme =
+      ec::ApplicationSchemeType::Proportional;
 
-    ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
-    ecm.run();
-    std::cout << ecm << std::endl;
-    EXPECT_TRUE(ecm.getResults().consideredEquivalent());
+  ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
+  ecm.run();
+  std::cout << ecm << std::endl;
+  EXPECT_TRUE(ecm.getResults().consideredEquivalent());
 }
 
 TEST_P(FunctionalityTest, Lookahead) {
-    qcAlternative.import(testAlternativeDir + "test_" + GetParam() + ".qasm");
+  qcAlternative.import(testAlternativeDir + "test_" + GetParam() + ".qasm");
 
-    config.execution.runAlternatingChecker = true;
-    config.application.alternatingScheme   = ec::ApplicationSchemeType::Lookahead;
+  config.execution.runAlternatingChecker = true;
+  config.application.alternatingScheme   = ec::ApplicationSchemeType::Lookahead;
 
-    ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
-    ecm.run();
-    std::cout << ecm << std::endl;
-    EXPECT_TRUE(ecm.getResults().consideredEquivalent());
+  ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
+  ecm.run();
+  std::cout << ecm << std::endl;
+  EXPECT_TRUE(ecm.getResults().consideredEquivalent());
 }
 
 TEST_P(FunctionalityTest, Naive) {
-    qcAlternative.import(testAlternativeDir + "test_" + GetParam() + ".qasm");
+  qcAlternative.import(testAlternativeDir + "test_" + GetParam() + ".qasm");
 
-    config.execution.runAlternatingChecker = true;
-    config.application.alternatingScheme   = ec::ApplicationSchemeType::OneToOne;
+  config.execution.runAlternatingChecker = true;
+  config.application.alternatingScheme   = ec::ApplicationSchemeType::OneToOne;
 
-    ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
-    ecm.run();
-    std::cout << ecm << std::endl;
-    EXPECT_TRUE(ecm.getResults().consideredEquivalent());
+  ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
+  ecm.run();
+  std::cout << ecm << std::endl;
+  EXPECT_TRUE(ecm.getResults().consideredEquivalent());
 }
 
 TEST_P(FunctionalityTest, CompilationFlow) {
-    qcAlternative.import(testAlternativeDir + "test_" + GetParam() + ".qasm");
+  qcAlternative.import(testAlternativeDir + "test_" + GetParam() + ".qasm");
 
-    config.execution.runAlternatingChecker = true;
-    config.application.alternatingScheme   = ec::ApplicationSchemeType::GateCost;
-    config.application.costFunction        = ec::LegacyIBMCostFunction;
+  config.execution.runAlternatingChecker = true;
+  config.application.alternatingScheme   = ec::ApplicationSchemeType::GateCost;
+  config.application.costFunction        = ec::LegacyIBMCostFunction;
 
-    ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
-    ecm.run();
-    std::cout << ecm << std::endl;
-    EXPECT_TRUE(ecm.getResults().consideredEquivalent());
+  ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
+  ecm.run();
+  std::cout << ecm << std::endl;
+  EXPECT_TRUE(ecm.getResults().consideredEquivalent());
 }
 
 TEST_P(FunctionalityTest, Simulation) {
-    qcAlternative.import(testAlternativeDir + "test_" + GetParam() + ".qasm");
+  qcAlternative.import(testAlternativeDir + "test_" + GetParam() + ".qasm");
 
-    config.execution.runSimulationChecker = true;
+  config.execution.runSimulationChecker = true;
 
-    ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
-    ecm.run();
-    std::cout << ecm << std::endl;
-    EXPECT_TRUE(ecm.getResults().consideredEquivalent());
+  ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
+  ecm.run();
+  std::cout << ecm << std::endl;
+  EXPECT_TRUE(ecm.getResults().consideredEquivalent());
 }
 
 TEST_P(FunctionalityTest, SimulationRandom1QBasis) {
-    qcAlternative.import(testAlternativeDir + "test_" + GetParam() + ".qasm");
+  qcAlternative.import(testAlternativeDir + "test_" + GetParam() + ".qasm");
 
-    config.execution.runSimulationChecker = true;
-    config.simulation.stateType           = ec::StateType::Random1QBasis;
+  config.execution.runSimulationChecker = true;
+  config.simulation.stateType           = ec::StateType::Random1QBasis;
 
-    ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
-    ecm.run();
-    std::cout << ecm << std::endl;
-    EXPECT_TRUE(ecm.getResults().consideredEquivalent());
+  ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
+  ecm.run();
+  std::cout << ecm << std::endl;
+  EXPECT_TRUE(ecm.getResults().consideredEquivalent());
 }
 
 TEST_P(FunctionalityTest, SimulationStabilizer) {
-    qcAlternative.import(testAlternativeDir + "test_" + GetParam() + ".qasm");
+  qcAlternative.import(testAlternativeDir + "test_" + GetParam() + ".qasm");
 
-    config.execution.runSimulationChecker = true;
-    config.simulation.stateType           = ec::StateType::Stabilizer;
+  config.execution.runSimulationChecker = true;
+  config.simulation.stateType           = ec::StateType::Stabilizer;
 
-    ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
-    ecm.run();
-    std::cout << ecm << std::endl;
-    EXPECT_TRUE(ecm.getResults().consideredEquivalent());
+  ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
+  ecm.run();
+  std::cout << ecm << std::endl;
+  EXPECT_TRUE(ecm.getResults().consideredEquivalent());
 }
 
 TEST_P(FunctionalityTest, SimulationParallel) {
-    qcAlternative.import(testAlternativeDir + "test_" + GetParam() + ".qasm");
+  qcAlternative.import(testAlternativeDir + "test_" + GetParam() + ".qasm");
 
-    config.execution.runSimulationChecker = true;
-    config.execution.parallel             = true;
-    config.execution.nthreads             = std::thread::hardware_concurrency() + 1U;
-    config.simulation.maxSims             = std::thread::hardware_concurrency() + 1U;
+  config.execution.runSimulationChecker = true;
+  config.execution.parallel             = true;
+  config.execution.nthreads = std::thread::hardware_concurrency() + 1U;
+  config.simulation.maxSims = std::thread::hardware_concurrency() + 1U;
 
-    ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
-    ecm.run();
-    std::cout << ecm << std::endl;
-    EXPECT_TRUE(ecm.getResults().consideredEquivalent());
+  ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
+  ecm.run();
+  std::cout << ecm << std::endl;
+  EXPECT_TRUE(ecm.getResults().consideredEquivalent());
 }
 
 TEST_F(FunctionalityTest, test2) {
-    testOriginal = "./circuits/test/test2.real";
-    qcOriginal.import(testOriginal);
-    qcAlternative.import(testAlternativeDir + "test2_optimized.qasm");
+  testOriginal = "./circuits/test/test2.real";
+  qcOriginal.import(testOriginal);
+  qcAlternative.import(testAlternativeDir + "test2_optimized.qasm");
 
-    config.execution.runConstructionChecker = true;
+  config.execution.runConstructionChecker = true;
 
-    ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
-    ecm.run();
-    std::cout << ecm << std::endl;
-    EXPECT_TRUE(ecm.getResults().consideredEquivalent());
+  ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
+  ecm.run();
+  std::cout << ecm << std::endl;
+  EXPECT_TRUE(ecm.getResults().consideredEquivalent());
 
-    config.execution.runConstructionChecker = false;
-    config.execution.runAlternatingChecker  = true;
-    config.application.alternatingScheme    = ec::ApplicationSchemeType::Proportional;
+  config.execution.runConstructionChecker = false;
+  config.execution.runAlternatingChecker  = true;
+  config.application.alternatingScheme =
+      ec::ApplicationSchemeType::Proportional;
 
-    ec::EquivalenceCheckingManager ecm2(qcOriginal, qcAlternative, config);
-    ecm2.run();
-    std::cout << ecm2.toString() << std::endl;
-    EXPECT_TRUE(ecm2.getResults().consideredEquivalent());
+  ec::EquivalenceCheckingManager ecm2(qcOriginal, qcAlternative, config);
+  ecm2.run();
+  std::cout << ecm2.toString() << std::endl;
+  EXPECT_TRUE(ecm2.getResults().consideredEquivalent());
 
-    config.application.alternatingScheme = ec::ApplicationSchemeType::Lookahead;
+  config.application.alternatingScheme = ec::ApplicationSchemeType::Lookahead;
 
-    ec::EquivalenceCheckingManager ecm3(qcOriginal, qcAlternative, config);
-    ecm3.run();
-    std::cout << ecm3.toString() << std::endl;
-    EXPECT_TRUE(ecm3.getResults().consideredEquivalent());
+  ec::EquivalenceCheckingManager ecm3(qcOriginal, qcAlternative, config);
+  ecm3.run();
+  std::cout << ecm3.toString() << std::endl;
+  EXPECT_TRUE(ecm3.getResults().consideredEquivalent());
 
-    config.application.alternatingScheme = ec::ApplicationSchemeType::OneToOne;
+  config.application.alternatingScheme = ec::ApplicationSchemeType::OneToOne;
 
-    ec::EquivalenceCheckingManager ecm4(qcOriginal, qcAlternative, config);
-    ecm4.run();
-    std::cout << ecm4.toString() << std::endl;
-    EXPECT_TRUE(ecm4.getResults().consideredEquivalent());
+  ec::EquivalenceCheckingManager ecm4(qcOriginal, qcAlternative, config);
+  ecm4.run();
+  std::cout << ecm4.toString() << std::endl;
+  EXPECT_TRUE(ecm4.getResults().consideredEquivalent());
 
-    config.application.alternatingScheme = ec::ApplicationSchemeType::GateCost;
-    config.application.costFunction      = ec::LegacyIBMCostFunction;
+  config.application.alternatingScheme = ec::ApplicationSchemeType::GateCost;
+  config.application.costFunction      = ec::LegacyIBMCostFunction;
 
-    ec::EquivalenceCheckingManager ecm5(qcOriginal, qcAlternative, config);
-    ecm5.run();
-    std::cout << ecm5.toString() << std::endl;
-    EXPECT_TRUE(ecm5.getResults().consideredEquivalent());
+  ec::EquivalenceCheckingManager ecm5(qcOriginal, qcAlternative, config);
+  ecm5.run();
+  std::cout << ecm5.toString() << std::endl;
+  EXPECT_TRUE(ecm5.getResults().consideredEquivalent());
 }

--- a/test/legacy/test_general.cpp
+++ b/test/legacy/test_general.cpp
@@ -1,6 +1,6 @@
 //
-// This file is part of MQT QCEC library which is released under the MIT license.
-// See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
 #include "EquivalenceCheckingManager.hpp"
@@ -14,172 +14,174 @@
 
 using ::testing::HasSubstr;
 
-class GeneralTest: public ::testing::Test {
+class GeneralTest : public ::testing::Test {
 protected:
-    qc::QuantumComputation qc1;
-    qc::QuantumComputation qc2;
+  qc::QuantumComputation qc1;
+  qc::QuantumComputation qc2;
 };
 
 TEST_F(GeneralTest, DynamicCircuit) {
-    auto s   = qc::BitString(15U);
-    auto bv  = qc::BernsteinVazirani(s);
-    auto dbv = qc::BernsteinVazirani(s, true);
+  auto s   = qc::BitString(15U);
+  auto bv  = qc::BernsteinVazirani(s);
+  auto dbv = qc::BernsteinVazirani(s, true);
 
-    auto config = ec::Configuration{};
-    EXPECT_THROW(ec::EquivalenceCheckingManager(bv, dbv, config), std::runtime_error);
+  auto config = ec::Configuration{};
+  EXPECT_THROW(ec::EquivalenceCheckingManager(bv, dbv, config),
+               std::runtime_error);
 
-    config.optimizations.transformDynamicCircuit = true;
+  config.optimizations.transformDynamicCircuit = true;
 
-    auto ecm = ec::EquivalenceCheckingManager(bv, dbv, config);
+  auto ecm = ec::EquivalenceCheckingManager(bv, dbv, config);
 
-    ecm.run();
+  ecm.run();
 
-    EXPECT_TRUE(ecm.getResults().consideredEquivalent());
+  EXPECT_TRUE(ecm.getResults().consideredEquivalent());
 
-    std::cout << ecm.toString() << std::endl;
+  std::cout << ecm.toString() << std::endl;
 
-    auto ecm2 = ec::EquivalenceCheckingManager(dbv, dbv, config);
+  auto ecm2 = ec::EquivalenceCheckingManager(dbv, dbv, config);
 
-    ecm2.run();
+  ecm2.run();
 
-    EXPECT_TRUE(ecm2.getResults().consideredEquivalent());
+  EXPECT_TRUE(ecm2.getResults().consideredEquivalent());
 
-    std::cout << ecm2.toString() << std::endl;
+  std::cout << ecm2.toString() << std::endl;
 }
 
 TEST_F(GeneralTest, FixOutputPermutationMismatch) {
-    qc1.addQubitRegister(2U);
-    qc1.x(0);
-    qc1.x(1);
-    qc1.setLogicalQubitAncillary(1);
-    std::cout << qc1 << std::endl;
+  qc1.addQubitRegister(2U);
+  qc1.x(0);
+  qc1.x(1);
+  qc1.setLogicalQubitAncillary(1);
+  std::cout << qc1 << std::endl;
 
-    qc2.addQubitRegister(3U);
-    qc2.x(0);
-    qc2.i(1);
-    qc2.x(2);
+  qc2.addQubitRegister(3U);
+  qc2.x(0);
+  qc2.i(1);
+  qc2.x(2);
 
-    qc2.outputPermutation.erase(1);
-    qc2.setLogicalQubitAncillary(1);
-    qc2.setLogicalQubitGarbage(1);
-    std::cout << static_cast<int>(qc2.getNqubits()) << std::endl;
-    std::cout << qc2 << std::endl;
+  qc2.outputPermutation.erase(1);
+  qc2.setLogicalQubitAncillary(1);
+  qc2.setLogicalQubitGarbage(1);
+  std::cout << static_cast<int>(qc2.getNqubits()) << std::endl;
+  std::cout << qc2 << std::endl;
 
-    auto config                                       = ec::Configuration{};
-    config.optimizations.fixOutputPermutationMismatch = true;
-    ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
-    ecm.run();
-    EXPECT_TRUE(ecm.getResults().consideredEquivalent());
+  auto config                                       = ec::Configuration{};
+  config.optimizations.fixOutputPermutationMismatch = true;
+  ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
+  ecm.run();
+  EXPECT_TRUE(ecm.getResults().consideredEquivalent());
 
-    // also try post initialization routine
-    ec::EquivalenceCheckingManager ecm2(qc1, qc2);
-    ecm2.runFixOutputPermutationMismatch();
-    ecm2.run();
-    EXPECT_TRUE(ecm2.getResults().consideredEquivalent());
+  // also try post initialization routine
+  ec::EquivalenceCheckingManager ecm2(qc1, qc2);
+  ecm2.runFixOutputPermutationMismatch();
+  ecm2.run();
+  EXPECT_TRUE(ecm2.getResults().consideredEquivalent());
 }
 
 TEST_F(GeneralTest, RemoveDiagonalGatesBeforeMeasure) {
-    qc1.addQubitRegister(1U);
-    qc1.addClassicalRegister(1U);
-    qc1.x(0);
-    qc1.measure(0, 0U);
-    std::cout << qc1 << std::endl;
-    std::cout << "-----------------------------" << std::endl;
+  qc1.addQubitRegister(1U);
+  qc1.addClassicalRegister(1U);
+  qc1.x(0);
+  qc1.measure(0, 0U);
+  std::cout << qc1 << std::endl;
+  std::cout << "-----------------------------" << std::endl;
 
-    qc2.addQubitRegister(1U);
-    qc2.addClassicalRegister(1U);
-    qc2.x(0);
-    qc2.z(0);
-    qc2.measure(0, 0U);
-    std::cout << qc2 << std::endl;
-    std::cout << "-----------------------------" << std::endl;
+  qc2.addQubitRegister(1U);
+  qc2.addClassicalRegister(1U);
+  qc2.x(0);
+  qc2.z(0);
+  qc2.measure(0, 0U);
+  std::cout << qc2 << std::endl;
+  std::cout << "-----------------------------" << std::endl;
 
-    // the standard check should reveal that both circuits are not equivalent
-    auto ecm = ec::EquivalenceCheckingManager(qc1, qc2);
-    ecm.run();
-    EXPECT_FALSE(ecm.getResults().consideredEquivalent());
-    std::cout << ecm.toString() << std::endl;
+  // the standard check should reveal that both circuits are not equivalent
+  auto ecm = ec::EquivalenceCheckingManager(qc1, qc2);
+  ecm.run();
+  EXPECT_FALSE(ecm.getResults().consideredEquivalent());
+  std::cout << ecm.toString() << std::endl;
 
-    // simulations should suggest both circuits to be equivalent
-    ecm.reset();
-    ecm.setAlternatingChecker(false);
-    ecm.setZXChecker(false);
-    ecm.run();
-    EXPECT_TRUE(ecm.getResults().consideredEquivalent());
-    std::cout << ecm.toString() << std::endl;
+  // simulations should suggest both circuits to be equivalent
+  ecm.reset();
+  ecm.setAlternatingChecker(false);
+  ecm.setZXChecker(false);
+  ecm.run();
+  EXPECT_TRUE(ecm.getResults().consideredEquivalent());
+  std::cout << ecm.toString() << std::endl;
 
-    // if configured to remove diagonal gates before measurements, the circuits are equivalent
-    auto config                                           = ec::Configuration{};
-    config.optimizations.removeDiagonalGatesBeforeMeasure = true;
-    auto ecm2                                             = ec::EquivalenceCheckingManager(qc1, qc2, config);
-    ecm2.run();
-    EXPECT_TRUE(ecm2.getResults().consideredEquivalent());
-    std::cout << ecm2.toString() << std::endl;
+  // if configured to remove diagonal gates before measurements, the circuits
+  // are equivalent
+  auto config                                           = ec::Configuration{};
+  config.optimizations.removeDiagonalGatesBeforeMeasure = true;
+  auto ecm2 = ec::EquivalenceCheckingManager(qc1, qc2, config);
+  ecm2.run();
+  EXPECT_TRUE(ecm2.getResults().consideredEquivalent());
+  std::cout << ecm2.toString() << std::endl;
 }
 
 TEST_F(GeneralTest, NothingToDo) {
-    qc1.addQubitRegister(1U);
-    qc1.x(0);
-    qc2.addQubitRegister(1U);
-    qc2.x(0);
+  qc1.addQubitRegister(1U);
+  qc1.x(0);
+  qc2.addQubitRegister(1U);
+  qc2.x(0);
 
-    auto config                             = ec::Configuration{};
-    config.execution.runAlternatingChecker  = false;
-    config.execution.runSimulationChecker   = false;
-    config.execution.runConstructionChecker = false;
-    config.execution.runZXChecker           = false;
+  auto config                             = ec::Configuration{};
+  config.execution.runAlternatingChecker  = false;
+  config.execution.runSimulationChecker   = false;
+  config.execution.runConstructionChecker = false;
+  config.execution.runZXChecker           = false;
 
-    auto ecm = ec::EquivalenceCheckingManager(qc1, qc2, config);
-    ecm.run();
-    EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::NoInformation);
+  auto ecm = ec::EquivalenceCheckingManager(qc1, qc2, config);
+  ecm.run();
+  EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::NoInformation);
 }
 
 TEST_F(GeneralTest, NoGateCancellation) {
-    qc1.addQubitRegister(2U);
-    qc2.addQubitRegister(2U);
+  qc1.addQubitRegister(2U);
+  qc2.addQubitRegister(2U);
 
-    // ignore swaps
-    qc1.swap(0, 1);
-    qc2.swap(0, 1);
+  // ignore swaps
+  qc1.swap(0, 1);
+  qc2.swap(0, 1);
 
-    // different gates that cannot be cancelled
-    qc1.z(0);
-    qc1.x(1);
-    qc2.x(1);
-    qc2.z(0);
+  // different gates that cannot be cancelled
+  qc1.z(0);
+  qc1.x(1);
+  qc2.x(1);
+  qc2.z(0);
 
-    // single qubit gates that cannot be cancelled
-    qc1.x(0);
-    qc2.x(1);
-    qc1.x(1);
-    qc2.x(0);
+  // single qubit gates that cannot be cancelled
+  qc1.x(0);
+  qc2.x(1);
+  qc1.x(1);
+  qc2.x(0);
 
-    // two-qubit gates that cannot be cancelled
-    qc1.x(0, 1_pc);
-    qc2.x(1, 0_pc);
-    qc1.x(0, 1_pc);
-    qc2.x(1, 0_pc);
+  // two-qubit gates that cannot be cancelled
+  qc1.x(0, 1_pc);
+  qc2.x(1, 0_pc);
+  qc1.x(0, 1_pc);
+  qc2.x(1, 0_pc);
 
-    // gates with parameters that cannot be cancelled
-    qc1.phase(0, 2.0);
-    qc2.phase(0, -2.0);
-    qc1.phase(0, -2.0);
-    qc2.phase(0, 2.0);
+  // gates with parameters that cannot be cancelled
+  qc1.phase(0, 2.0);
+  qc2.phase(0, -2.0);
+  qc1.phase(0, -2.0);
+  qc2.phase(0, 2.0);
 
-    // gates with different number of controls that cannot be cancelled
-    qc1.x(0);
-    qc2.x(0, 1_pc);
-    qc1.x(0, 1_pc);
-    qc2.x(0);
+  // gates with different number of controls that cannot be cancelled
+  qc1.x(0);
+  qc2.x(0, 1_pc);
+  qc1.x(0, 1_pc);
+  qc2.x(0);
 
-    auto config                               = ec::Configuration{};
-    config.optimizations.reorderOperations    = false;
-    config.optimizations.fuseSingleQubitGates = false;
-    config.optimizations.reconstructSWAPs     = false;
-    config.application.alternatingScheme      = ec::ApplicationSchemeType::OneToOne;
+  auto config                               = ec::Configuration{};
+  config.optimizations.reorderOperations    = false;
+  config.optimizations.fuseSingleQubitGates = false;
+  config.optimizations.reconstructSWAPs     = false;
+  config.application.alternatingScheme = ec::ApplicationSchemeType::OneToOne;
 
-    ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
-    ecm.run();
-    EXPECT_TRUE(ecm.getResults().consideredEquivalent());
-    std::cout << ecm.toString() << std::endl;
+  ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
+  ecm.run();
+  EXPECT_TRUE(ecm.getResults().consideredEquivalent());
+  std::cout << ecm.toString() << std::endl;
 }

--- a/test/legacy/test_journal.cpp
+++ b/test/legacy/test_journal.cpp
@@ -1,6 +1,6 @@
 //
-// This file is part of MQT QCEC library which is released under the MIT license.
-// See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
 #include "EquivalenceCheckingManager.hpp"
@@ -11,392 +11,398 @@
 #include <random>
 #include <string>
 
-class JournalTestNonEQ: public testing::TestWithParam<std::tuple<std::string, unsigned short>> {
+class JournalTestNonEQ
+    : public testing::TestWithParam<std::tuple<std::string, unsigned short>> {
 protected:
-    qc::QuantumComputation qcOriginal;
-    qc::QuantumComputation qcTranspiled;
-    ec::Configuration      config;
+  qc::QuantumComputation qcOriginal;
+  qc::QuantumComputation qcTranspiled;
+  ec::Configuration      config;
 
-    std::string testOriginalDir   = "./circuits/original/";
-    std::string testTranspiledDir = "./circuits/transpiled/";
+  std::string testOriginalDir   = "./circuits/original/";
+  std::string testTranspiledDir = "./circuits/transpiled/";
 
-    unsigned short tries = 10U;
+  unsigned short tries = 10U;
 
-    double      minTime = 0.;
-    double      maxTime = 0.;
-    double      avgTime = 0.;
-    std::size_t minSims = 0U;
-    std::size_t maxSims = 0U;
-    double      avgSims = 0.;
+  double      minTime = 0.;
+  double      maxTime = 0.;
+  double      avgTime = 0.;
+  std::size_t minSims = 0U;
+  std::size_t maxSims = 0U;
+  double      avgSims = 0.;
 
-    std::string transpiledFile{};
+  std::string transpiledFile{};
 
-    std::mt19937_64                                   mt;
-    std::uniform_int_distribution<unsigned long long> distribution;
-    std::function<unsigned long long()>               rng;
+  std::mt19937_64                                   mt;
+  std::uniform_int_distribution<unsigned long long> distribution;
+  std::function<unsigned long long()>               rng;
 
-    unsigned short                         gatesToRemove = 0U;
-    std::set<std::set<unsigned long long>> alreadyRemoved{};
+  unsigned short                         gatesToRemove = 0U;
+  std::set<std::set<unsigned long long>> alreadyRemoved{};
 
-    unsigned short successes = 0U;
+  unsigned short successes = 0U;
 
-    static bool setExists(const std::set<std::set<unsigned long long>>& all, const std::set<unsigned long long>& test) {
-        // first entry
-        if (all.empty()) {
-            return false;
-        }
-
-        for (const auto& set: all) {
-            bool equals = true;
-            for (auto setit = set.begin(), testit = test.begin(); setit != set.end(); ++setit, ++testit) {
-                if (*setit != *testit) {
-                    equals = false;
-                    break;
-                }
-            }
-            if (equals) {
-                return true;
-            }
-        }
-        return false;
+  static bool setExists(const std::set<std::set<unsigned long long>>& all,
+                        const std::set<unsigned long long>&           test) {
+    // first entry
+    if (all.empty()) {
+      return false;
     }
 
-    void SetUp() override {
-        std::stringstream ss{};
-        ss << testTranspiledDir << std::get<0>(GetParam()) << "_transpiled.qasm";
-        transpiledFile = ss.str();
-
-        std::array<std::mt19937_64::result_type, std::mt19937_64::state_size> random_data{};
-        std::random_device                                                    rd;
-        std::generate(begin(random_data), end(random_data), [&]() { return rd(); });
-        std::seed_seq seeds(begin(random_data), end(random_data));
-        mt.seed(seeds);
-        distribution = decltype(distribution)(0U, qcTranspiled.getNops() - 1U);
-        rng          = [this]() { return distribution(mt); };
-
-        gatesToRemove = std::get<1>(GetParam());
-
-        minTime = 0.;
-        maxTime = 0.;
-        avgTime = 0.;
-        minSims = 0U;
-        maxSims = 0U;
-        avgSims = 0.;
-    }
-
-    void addToStatistics(unsigned short try_count, double time, std::size_t nsims) {
-        if (try_count == 0U) {
-            minTime = time;
-            maxTime = time;
-            avgTime = time;
-            minSims = nsims;
-            maxSims = nsims;
-            avgSims = static_cast<double>(nsims);
-        } else {
-            minTime = std::min(minTime, time);
-            minSims = std::min(minSims, nsims);
-            maxTime = std::max(maxTime, time);
-            maxSims = std::max(maxSims, nsims);
-            avgTime = (avgTime * try_count + time) / static_cast<double>(try_count + 1U);
-            avgSims = (avgSims * try_count + static_cast<double>(nsims)) / static_cast<double>(try_count + 1U);
+    for (const auto& set : all) {
+      bool equals = true;
+      for (auto setit = set.begin(), testit = test.begin(); setit != set.end();
+           ++setit, ++testit) {
+        if (*setit != *testit) {
+          equals = false;
+          break;
         }
+      }
+      if (equals) {
+        return true;
+      }
     }
+    return false;
+  }
+
+  void SetUp() override {
+    std::stringstream ss{};
+    ss << testTranspiledDir << std::get<0>(GetParam()) << "_transpiled.qasm";
+    transpiledFile = ss.str();
+
+    std::array<std::mt19937_64::result_type, std::mt19937_64::state_size>
+                       random_data{};
+    std::random_device rd;
+    std::generate(begin(random_data), end(random_data), [&]() { return rd(); });
+    std::seed_seq seeds(begin(random_data), end(random_data));
+    mt.seed(seeds);
+    distribution = decltype(distribution)(0U, qcTranspiled.getNops() - 1U);
+    rng          = [this]() { return distribution(mt); };
+
+    gatesToRemove = std::get<1>(GetParam());
+
+    minTime = 0.;
+    maxTime = 0.;
+    avgTime = 0.;
+    minSims = 0U;
+    maxSims = 0U;
+    avgSims = 0.;
+  }
+
+  void addToStatistics(unsigned short try_count, double time,
+                       std::size_t nsims) {
+    if (try_count == 0U) {
+      minTime = time;
+      maxTime = time;
+      avgTime = time;
+      minSims = nsims;
+      maxSims = nsims;
+      avgSims = static_cast<double>(nsims);
+    } else {
+      minTime = std::min(minTime, time);
+      minSims = std::min(minSims, nsims);
+      maxTime = std::max(maxTime, time);
+      maxSims = std::max(maxSims, nsims);
+      avgTime =
+          (avgTime * try_count + time) / static_cast<double>(try_count + 1U);
+      avgSims = (avgSims * try_count + static_cast<double>(nsims)) /
+                static_cast<double>(try_count + 1U);
+    }
+  }
 };
 
-INSTANTIATE_TEST_SUITE_P(Journal, JournalTestNonEQ,
-                         testing::Combine(
-                             testing::Values(
-                                 "dk27_225",
-                                 "pcler8_248",
-                                 "5xp1_194",
-                                 "alu1_198",
-                                 //				                         "mlp4_245",
-                                 "dk17_224",
-                                 //				                         "add6_196",
-                                 //				                         "C7552_205",
-                                 "cu_219",
-                                 //				                         "example2_231",
-                                 "c2_181",
-                                 "rd73_312",
-                                 //				                         "cm150a_210",
-                                 "cm163a_213",
-                                 "c2_182",
-                                 "sym9_317",
-                                 "mod5adder_306",
-                                 "rd84_313"
-                                 //				                         "cm151a_211",
-                                 //				                         "apla_203"
-                                 ),
-                             testing::Range(static_cast<unsigned short>(1U), static_cast<unsigned short>(4U), 2)),
-                         [](const testing::TestParamInfo<JournalTestNonEQ::ParamType>& info) {
-	                         std::string name = std::get<0>(info.param);
-	                         unsigned short gates_to_remove = std::get<1>(info.param);
-	                         std::replace( name.begin(), name.end(), '-', '_');
-	                         std::stringstream ss{};
-	                         ss << name << "_removed_" << gates_to_remove;
-	                         return ss.str(); });
+INSTANTIATE_TEST_SUITE_P(
+    Journal, JournalTestNonEQ,
+    testing::Combine(
+        testing::Values(
+            "dk27_225", "pcler8_248", "5xp1_194", "alu1_198",
+            //				                         "mlp4_245",
+            "dk17_224",
+            //				                         "add6_196",
+            //				                         "C7552_205",
+            "cu_219",
+            //				                         "example2_231",
+            "c2_181", "rd73_312",
+            //				                         "cm150a_210",
+            "cm163a_213", "c2_182", "sym9_317", "mod5adder_306", "rd84_313"
+            //				                         "cm151a_211",
+            //				                         "apla_203"
+            ),
+        testing::Range(static_cast<unsigned short>(1U),
+                       static_cast<unsigned short>(4U), 2)),
+    [](const testing::TestParamInfo<JournalTestNonEQ::ParamType>& info) {
+      std::string    name            = std::get<0>(info.param);
+      unsigned short gates_to_remove = std::get<1>(info.param);
+      std::replace(name.begin(), name.end(), '-', '_');
+      std::stringstream ss{};
+      ss << name << "_removed_" << gates_to_remove;
+      return ss.str();
+    });
 
 TEST_P(JournalTestNonEQ, PowerOfSimulation) {
-    config.execution.runAlternatingChecker  = false;
-    config.execution.runConstructionChecker = false;
-    config.execution.runSimulationChecker   = true;
-    config.execution.parallel               = false;
-    config.execution.timeout                = 60s;
-    config.simulation.maxSims               = 16U;
-    config.application.simulationScheme     = ec::ApplicationSchemeType::Sequential;
+  config.execution.runAlternatingChecker  = false;
+  config.execution.runConstructionChecker = false;
+  config.execution.runSimulationChecker   = true;
+  config.execution.parallel               = false;
+  config.execution.timeout                = 60s;
+  config.simulation.maxSims               = 16U;
+  config.application.simulationScheme = ec::ApplicationSchemeType::Sequential;
 
-    for (unsigned short i = 0U; i < tries; ++i) {
-        qcOriginal.import(testOriginalDir + std::get<0>(GetParam()) + ".real");
+  for (unsigned short i = 0U; i < tries; ++i) {
+    qcOriginal.import(testOriginalDir + std::get<0>(GetParam()) + ".real");
 
-        // generate non-eq circuit
-        std::set<unsigned long long> removed{};
-        do {
-            qcTranspiled.import(transpiledFile);
-            removed.clear();
-            for (unsigned short j = 0U; j < gatesToRemove; ++j) {
-                auto gate_to_remove = rng() % qcTranspiled.getNops();
-                while (removed.count(gate_to_remove) != 0U) {
-                    gate_to_remove = rng() % qcTranspiled.getNops();
-                }
-                removed.insert(gate_to_remove);
-                auto it = qcTranspiled.begin();
-                std::advance(it, gate_to_remove);
-                if (it == qcTranspiled.end()) {
-                    continue;
-                }
-
-                qcTranspiled.erase(it);
-            }
-        } while (setExists(alreadyRemoved, removed));
-        alreadyRemoved.insert(removed);
-        ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, config);
-        ecm.run();
-        auto results = ecm.getResults();
-        std::cout << "[" << i << "] ";
-        std::cout << toString(results.equivalence) << std::endl;
-        addToStatistics(i, results.checkTime + results.preprocessingTime, results.performedSimulations);
-        if (results.equivalence == ec::EquivalenceCriterion::NotEquivalent) {
-            successes++;
+    // generate non-eq circuit
+    std::set<unsigned long long> removed{};
+    do {
+      qcTranspiled.import(transpiledFile);
+      removed.clear();
+      for (unsigned short j = 0U; j < gatesToRemove; ++j) {
+        auto gate_to_remove = rng() % qcTranspiled.getNops();
+        while (removed.count(gate_to_remove) != 0U) {
+          gate_to_remove = rng() % qcTranspiled.getNops();
         }
+        removed.insert(gate_to_remove);
+        auto it = qcTranspiled.begin();
+        std::advance(it, gate_to_remove);
+        if (it == qcTranspiled.end()) {
+          continue;
+        }
+
+        qcTranspiled.erase(it);
+      }
+    } while (setExists(alreadyRemoved, removed));
+    alreadyRemoved.insert(removed);
+    ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, config);
+    ecm.run();
+    auto results = ecm.getResults();
+    std::cout << "[" << i << "] ";
+    std::cout << toString(results.equivalence) << std::endl;
+    addToStatistics(i, results.checkTime + results.preprocessingTime,
+                    results.performedSimulations);
+    if (results.equivalence == ec::EquivalenceCriterion::NotEquivalent) {
+      successes++;
     }
-    std::cout << qcOriginal.getName() << ";" << qcOriginal.getNqubits() << ";" << qcOriginal.getNops() << ";" << qcTranspiled.getNops()
-              << ";" << tries << ";"
-              << minSims << ";" << maxSims << ";" << avgSims << ";"
-              << minTime << ";" << maxTime << ";" << avgTime << ";"
-              << static_cast<double>(successes) / static_cast<double>(tries) << ";" << std::endl;
+  }
+  std::cout << qcOriginal.getName() << ";" << qcOriginal.getNqubits() << ";"
+            << qcOriginal.getNops() << ";" << qcTranspiled.getNops() << ";"
+            << tries << ";" << minSims << ";" << maxSims << ";" << avgSims
+            << ";" << minTime << ";" << maxTime << ";" << avgTime << ";"
+            << static_cast<double>(successes) / static_cast<double>(tries)
+            << ";" << std::endl;
 }
 
 TEST_P(JournalTestNonEQ, PowerOfSimulationParallel) {
-    config.execution.runAlternatingChecker  = false;
-    config.execution.runConstructionChecker = false;
-    config.execution.runZXChecker           = false;
-    config.execution.runSimulationChecker   = true;
-    config.execution.parallel               = true;
-    config.execution.timeout                = 60s;
-    config.simulation.maxSims               = 16U;
-    config.application.simulationScheme     = ec::ApplicationSchemeType::Sequential;
+  config.execution.runAlternatingChecker  = false;
+  config.execution.runConstructionChecker = false;
+  config.execution.runZXChecker           = false;
+  config.execution.runSimulationChecker   = true;
+  config.execution.parallel               = true;
+  config.execution.timeout                = 60s;
+  config.simulation.maxSims               = 16U;
+  config.application.simulationScheme = ec::ApplicationSchemeType::Sequential;
 
-    for (unsigned short i = 0; i < tries; ++i) {
-        qcOriginal.import(testOriginalDir + std::get<0>(GetParam()) + ".real");
+  for (unsigned short i = 0; i < tries; ++i) {
+    qcOriginal.import(testOriginalDir + std::get<0>(GetParam()) + ".real");
 
-        // generate non-eq circuit
-        std::set<unsigned long long> removed{};
-        do {
-            qcTranspiled.import(transpiledFile);
-            removed.clear();
-            for (unsigned short j = 0U; j < gatesToRemove; ++j) {
-                auto gate_to_remove = rng() % qcTranspiled.getNops();
-                while (removed.count(gate_to_remove) != 0U) {
-                    gate_to_remove = rng() % qcTranspiled.getNops();
-                }
-                removed.insert(gate_to_remove);
-                auto it = qcTranspiled.begin();
-                std::advance(it, gate_to_remove);
-                if (it == qcTranspiled.end()) {
-                    continue;
-                }
-
-                qcTranspiled.erase(it);
-            }
-        } while (setExists(alreadyRemoved, removed));
-        alreadyRemoved.insert(removed);
-        ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, config);
-        ecm.run();
-        auto results = ecm.getResults();
-        std::cout << "[" << i << "] ";
-        std::cout << toString(results.equivalence) << std::endl;
-        addToStatistics(i, results.checkTime + results.preprocessingTime, results.performedSimulations);
-        if (results.equivalence == ec::EquivalenceCriterion::NotEquivalent) {
-            successes++;
+    // generate non-eq circuit
+    std::set<unsigned long long> removed{};
+    do {
+      qcTranspiled.import(transpiledFile);
+      removed.clear();
+      for (unsigned short j = 0U; j < gatesToRemove; ++j) {
+        auto gate_to_remove = rng() % qcTranspiled.getNops();
+        while (removed.count(gate_to_remove) != 0U) {
+          gate_to_remove = rng() % qcTranspiled.getNops();
         }
-    }
-    std::cout << qcOriginal.getName() << ";" << qcOriginal.getNqubits() << ";" << qcOriginal.getNops() << ";" << qcTranspiled.getNops()
-              << ";" << tries << ";"
-              << minSims << ";" << maxSims << ";" << avgSims << ";"
-              << minTime << ";" << maxTime << ";" << avgTime << ";"
-              << static_cast<double>(successes) / static_cast<double>(tries) << ";" << std::endl;
-}
+        removed.insert(gate_to_remove);
+        auto it = qcTranspiled.begin();
+        std::advance(it, gate_to_remove);
+        if (it == qcTranspiled.end()) {
+          continue;
+        }
 
-class JournalTestEQ: public testing::TestWithParam<std::string> {
-protected:
-    qc::QuantumComputation qcOriginal;
-    qc::QuantumComputation qcTranspiled;
-    ec::Configuration      config{};
-
-    std::string testOriginalDir   = "./circuits/original/";
-    std::string testTranspiledDir = "./circuits/transpiled/";
-
-    std::string transpiledFile{};
-
-    void SetUp() override {
-        config.execution.parallel               = false;
-        config.execution.runConstructionChecker = false;
-        config.execution.runAlternatingChecker  = false;
-        config.execution.runZXChecker           = false;
-        config.execution.runSimulationChecker   = false;
-        config.simulation.maxSims               = 16;
-        config.application.simulationScheme     = ec::ApplicationSchemeType::OneToOne;
-        config.execution.timeout                = 60s;
-
-        std::stringstream ss{};
-        ss << testTranspiledDir << GetParam() << "_transpiled.qasm";
-        transpiledFile = ss.str();
-
-        qcOriginal.import(testOriginalDir + GetParam() + ".real");
-        qcTranspiled.import(transpiledFile);
-    }
-};
-
-INSTANTIATE_TEST_SUITE_P(Journal, JournalTestEQ,
-                         testing::Values(
-                             "dk27_225",
-                             "pcler8_248",
-                             "5xp1_194",
-                             "alu1_198"
-                             //"mlp4_245"
-                             //"dk17_224",
-                             //"add6_196",
-                             //"C7552_205",
-                             //"cu_219",
-                             //"example2_231",
-                             //"c2_181",
-                             //"rd73_312",
-                             //"cm150a_210",
-                             //"cm163a_213",
-                             //"c2_182",
-                             //"sym9_317",
-                             //"mod5adder_306",
-                             //"rd84_313",
-                             //"cm151a_211",
-                             //"apla_203"
-                             ),
-                         [](const testing::TestParamInfo<JournalTestEQ::ParamType>& info) {
-	                         std::string name = info.param;
-	                         std::replace( name.begin(), name.end(), '-', '_');
-	                         std::stringstream ss{};
-	                         ss << name;
-	                         return ss.str(); });
-
-TEST_P(JournalTestEQ, EQReference) {
-    config.execution.runConstructionChecker = true;
-    config.application.constructionScheme   = ec::ApplicationSchemeType::OneToOne;
-
+        qcTranspiled.erase(it);
+      }
+    } while (setExists(alreadyRemoved, removed));
+    alreadyRemoved.insert(removed);
     ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, config);
     ecm.run();
-    std::cout << ecm.toString() << std::endl;
-    EXPECT_TRUE(ecm.getResults().consideredEquivalent());
+    auto results = ecm.getResults();
+    std::cout << "[" << i << "] ";
+    std::cout << toString(results.equivalence) << std::endl;
+    addToStatistics(i, results.checkTime + results.preprocessingTime,
+                    results.performedSimulations);
+    if (results.equivalence == ec::EquivalenceCriterion::NotEquivalent) {
+      successes++;
+    }
+  }
+  std::cout << qcOriginal.getName() << ";" << qcOriginal.getNqubits() << ";"
+            << qcOriginal.getNops() << ";" << qcTranspiled.getNops() << ";"
+            << tries << ";" << minSims << ";" << maxSims << ";" << avgSims
+            << ";" << minTime << ";" << maxTime << ";" << avgTime << ";"
+            << static_cast<double>(successes) / static_cast<double>(tries)
+            << ";" << std::endl;
+}
+
+class JournalTestEQ : public testing::TestWithParam<std::string> {
+protected:
+  qc::QuantumComputation qcOriginal;
+  qc::QuantumComputation qcTranspiled;
+  ec::Configuration      config{};
+
+  std::string testOriginalDir   = "./circuits/original/";
+  std::string testTranspiledDir = "./circuits/transpiled/";
+
+  std::string transpiledFile{};
+
+  void SetUp() override {
+    config.execution.parallel               = false;
+    config.execution.runConstructionChecker = false;
+    config.execution.runAlternatingChecker  = false;
+    config.execution.runZXChecker           = false;
+    config.execution.runSimulationChecker   = false;
+    config.simulation.maxSims               = 16;
+    config.application.simulationScheme = ec::ApplicationSchemeType::OneToOne;
+    config.execution.timeout            = 60s;
+
+    std::stringstream ss{};
+    ss << testTranspiledDir << GetParam() << "_transpiled.qasm";
+    transpiledFile = ss.str();
+
+    qcOriginal.import(testOriginalDir + GetParam() + ".real");
+    qcTranspiled.import(transpiledFile);
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    Journal, JournalTestEQ,
+    testing::Values("dk27_225", "pcler8_248", "5xp1_194", "alu1_198"
+                    //"mlp4_245"
+                    //"dk17_224",
+                    //"add6_196",
+                    //"C7552_205",
+                    //"cu_219",
+                    //"example2_231",
+                    //"c2_181",
+                    //"rd73_312",
+                    //"cm150a_210",
+                    //"cm163a_213",
+                    //"c2_182",
+                    //"sym9_317",
+                    //"mod5adder_306",
+                    //"rd84_313",
+                    //"cm151a_211",
+                    //"apla_203"
+                    ),
+    [](const testing::TestParamInfo<JournalTestEQ::ParamType>& info) {
+      std::string name = info.param;
+      std::replace(name.begin(), name.end(), '-', '_');
+      std::stringstream ss{};
+      ss << name;
+      return ss.str();
+    });
+
+TEST_P(JournalTestEQ, EQReference) {
+  config.execution.runConstructionChecker = true;
+  config.application.constructionScheme   = ec::ApplicationSchemeType::OneToOne;
+
+  ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, config);
+  ecm.run();
+  std::cout << ecm.toString() << std::endl;
+  EXPECT_TRUE(ecm.getResults().consideredEquivalent());
 }
 
 TEST_P(JournalTestEQ, EQNaive) {
-    config.execution.runAlternatingChecker = true;
-    config.application.alternatingScheme   = ec::ApplicationSchemeType::OneToOne;
+  config.execution.runAlternatingChecker = true;
+  config.application.alternatingScheme   = ec::ApplicationSchemeType::OneToOne;
 
-    ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, config);
-    ecm.run();
-    std::cout << ecm.toString() << std::endl;
-    EXPECT_TRUE(ecm.getResults().consideredEquivalent());
+  ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, config);
+  ecm.run();
+  std::cout << ecm.toString() << std::endl;
+  EXPECT_TRUE(ecm.getResults().consideredEquivalent());
 }
 
 TEST_P(JournalTestEQ, EQProportional) {
-    config.execution.runAlternatingChecker = true;
-    config.application.alternatingScheme   = ec::ApplicationSchemeType::Proportional;
+  config.execution.runAlternatingChecker = true;
+  config.application.alternatingScheme =
+      ec::ApplicationSchemeType::Proportional;
 
-    ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, config);
-    ecm.run();
-    std::cout << ecm.toString() << std::endl;
-    EXPECT_TRUE(ecm.getResults().consideredEquivalent());
+  ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, config);
+  ecm.run();
+  std::cout << ecm.toString() << std::endl;
+  EXPECT_TRUE(ecm.getResults().consideredEquivalent());
 }
 
 TEST_P(JournalTestEQ, EQLookahead) {
-    config.execution.runAlternatingChecker = true;
-    config.application.alternatingScheme   = ec::ApplicationSchemeType::Lookahead;
+  config.execution.runAlternatingChecker = true;
+  config.application.alternatingScheme   = ec::ApplicationSchemeType::Lookahead;
 
-    ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, config);
-    ecm.run();
-    std::cout << ecm.toString() << std::endl;
-    EXPECT_TRUE(ecm.getResults().consideredEquivalent());
+  ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, config);
+  ecm.run();
+  std::cout << ecm.toString() << std::endl;
+  EXPECT_TRUE(ecm.getResults().consideredEquivalent());
 }
 
 TEST_P(JournalTestEQ, EQPowerOfSimulation) {
-    config.execution.runSimulationChecker = true;
+  config.execution.runSimulationChecker = true;
 
-    ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, config);
-    ecm.run();
-    std::cout << ecm.toString() << std::endl;
-    EXPECT_TRUE(ecm.getResults().consideredEquivalent());
+  ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, config);
+  ecm.run();
+  std::cout << ecm.toString() << std::endl;
+  EXPECT_TRUE(ecm.getResults().consideredEquivalent());
 }
 
 TEST_P(JournalTestEQ, EQReferenceParallel) {
-    config.execution.parallel               = true;
-    config.execution.runConstructionChecker = true;
-    config.execution.runSimulationChecker   = true; // additionally run simulations
-    config.application.constructionScheme   = ec::ApplicationSchemeType::OneToOne;
+  config.execution.parallel               = true;
+  config.execution.runConstructionChecker = true;
+  config.execution.runSimulationChecker = true; // additionally run simulations
+  config.application.constructionScheme = ec::ApplicationSchemeType::OneToOne;
 
-    ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, config);
-    ecm.run();
-    std::cout << ecm.toString() << std::endl;
-    EXPECT_TRUE(ecm.getResults().consideredEquivalent());
+  ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, config);
+  ecm.run();
+  std::cout << ecm.toString() << std::endl;
+  EXPECT_TRUE(ecm.getResults().consideredEquivalent());
 }
 
 TEST_P(JournalTestEQ, EQNaiveParallel) {
-    config.execution.parallel              = true;
-    config.execution.runAlternatingChecker = true;
-    config.application.alternatingScheme   = ec::ApplicationSchemeType::OneToOne;
+  config.execution.parallel              = true;
+  config.execution.runAlternatingChecker = true;
+  config.application.alternatingScheme   = ec::ApplicationSchemeType::OneToOne;
 
-    ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, config);
-    ecm.run();
-    std::cout << ecm.toString() << std::endl;
-    EXPECT_TRUE(ecm.getResults().consideredEquivalent());
+  ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, config);
+  ecm.run();
+  std::cout << ecm.toString() << std::endl;
+  EXPECT_TRUE(ecm.getResults().consideredEquivalent());
 }
 
 TEST_P(JournalTestEQ, EQProportionalParallel) {
-    config.execution.parallel              = true;
-    config.execution.runAlternatingChecker = true;
-    config.application.alternatingScheme   = ec::ApplicationSchemeType::Proportional;
+  config.execution.parallel              = true;
+  config.execution.runAlternatingChecker = true;
+  config.application.alternatingScheme =
+      ec::ApplicationSchemeType::Proportional;
 
-    ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, config);
-    ecm.run();
-    std::cout << ecm.toString() << std::endl;
-    EXPECT_TRUE(ecm.getResults().consideredEquivalent());
+  ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, config);
+  ecm.run();
+  std::cout << ecm.toString() << std::endl;
+  EXPECT_TRUE(ecm.getResults().consideredEquivalent());
 }
 
 TEST_P(JournalTestEQ, EQLookaheadParallel) {
-    config.execution.parallel              = true;
-    config.execution.runAlternatingChecker = true;
-    config.application.alternatingScheme   = ec::ApplicationSchemeType::Lookahead;
+  config.execution.parallel              = true;
+  config.execution.runAlternatingChecker = true;
+  config.application.alternatingScheme   = ec::ApplicationSchemeType::Lookahead;
 
-    ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, config);
-    ecm.run();
-    std::cout << ecm.toString() << std::endl;
-    EXPECT_TRUE(ecm.getResults().consideredEquivalent());
+  ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, config);
+  ecm.run();
+  std::cout << ecm.toString() << std::endl;
+  EXPECT_TRUE(ecm.getResults().consideredEquivalent());
 }
 
 TEST_P(JournalTestEQ, EQPowerOfSimulationParallel) {
-    config.execution.parallel             = true;
-    config.execution.runSimulationChecker = true;
+  config.execution.parallel             = true;
+  config.execution.runSimulationChecker = true;
 
-    ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, config);
-    ecm.run();
-    std::cout << ecm.toString() << std::endl;
-    EXPECT_TRUE(ecm.getResults().consideredEquivalent());
+  ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, config);
+  ecm.run();
+  std::cout << ecm.toString() << std::endl;
+  EXPECT_TRUE(ecm.getResults().consideredEquivalent());
 }

--- a/test/legacy/test_simulation.cpp
+++ b/test/legacy/test_simulation.cpp
@@ -1,145 +1,146 @@
 //
-// This file is part of MQT QCEC library which is released under the MIT license.
-// See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
 #include "EquivalenceCheckingManager.hpp"
 
 #include "gtest/gtest.h"
 
-class SimulationTest: public ::testing::Test {
+class SimulationTest : public ::testing::Test {
 protected:
-    qc::QuantumComputation qcOriginal;
-    qc::QuantumComputation qcAlternative;
-    ec::Configuration      config{};
+  qc::QuantumComputation qcOriginal;
+  qc::QuantumComputation qcAlternative;
+  ec::Configuration      config{};
 
-    void SetUp() override {
-        config.execution.runAlternatingChecker  = false;
-        config.execution.runConstructionChecker = false;
-        config.execution.runSimulationChecker   = true;
-        config.execution.parallel               = false;
+  void SetUp() override {
+    config.execution.runAlternatingChecker  = false;
+    config.execution.runConstructionChecker = false;
+    config.execution.runSimulationChecker   = true;
+    config.execution.parallel               = false;
 
-        config.simulation.maxSims        = 8U;
-        config.simulation.storeCEXinput  = true;
-        config.simulation.storeCEXoutput = true;
-        config.simulation.seed           = 12345U;
-    }
+    config.simulation.maxSims        = 8U;
+    config.simulation.storeCEXinput  = true;
+    config.simulation.storeCEXoutput = true;
+    config.simulation.seed           = 12345U;
+  }
 };
 
 TEST_F(SimulationTest, Consistency) {
-    qcOriginal.import("./circuits/test/test_original.real");
-    qcAlternative.import("./circuits/test/test_erroneous.real");
+  qcOriginal.import("./circuits/test/test_original.real");
+  qcAlternative.import("./circuits/test/test_erroneous.real");
 
-    ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
-    ecm.run();
+  ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
+  ecm.run();
 
-    ec::EquivalenceCheckingManager ecm2(qcOriginal, qcAlternative, config);
-    ecm2.run();
+  ec::EquivalenceCheckingManager ecm2(qcOriginal, qcAlternative, config);
+  ecm2.run();
 
-    EXPECT_EQ(ecm.getResults().performedSimulations, ecm2.getResults().performedSimulations);
+  EXPECT_EQ(ecm.getResults().performedSimulations,
+            ecm2.getResults().performedSimulations);
 }
 
 TEST_F(SimulationTest, ClassicalStimuli) {
-    qcOriginal.import("./circuits/test/test_original.real");
-    qcAlternative.import("./circuits/test/test_alternative.real");
+  qcOriginal.import("./circuits/test/test_original.real");
+  qcAlternative.import("./circuits/test/test_alternative.real");
 
-    config.simulation.stateType = ec::StateType::ComputationalBasis;
-    ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
-    ecm.run();
-    std::cout << ecm.toString() << std::endl;
-    EXPECT_TRUE(ecm.getResults().consideredEquivalent());
+  config.simulation.stateType = ec::StateType::ComputationalBasis;
+  ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
+  ecm.run();
+  std::cout << ecm.toString() << std::endl;
+  EXPECT_TRUE(ecm.getResults().consideredEquivalent());
 
-    qcAlternative.import("./circuits/test/test_erroneous.real");
-    ec::EquivalenceCheckingManager ecm2(qcOriginal, qcAlternative, config);
-    ecm2.run();
-    std::cout << ecm2.toString() << std::endl;
-    EXPECT_FALSE(ecm2.getResults().consideredEquivalent());
+  qcAlternative.import("./circuits/test/test_erroneous.real");
+  ec::EquivalenceCheckingManager ecm2(qcOriginal, qcAlternative, config);
+  ecm2.run();
+  std::cout << ecm2.toString() << std::endl;
+  EXPECT_FALSE(ecm2.getResults().consideredEquivalent());
 }
 
 TEST_F(SimulationTest, LocalStimuli) {
-    qcOriginal.import("./circuits/test/test_original.real");
-    qcAlternative.import("./circuits/test/test_alternative.real");
+  qcOriginal.import("./circuits/test/test_original.real");
+  qcAlternative.import("./circuits/test/test_alternative.real");
 
-    config.simulation.stateType = ec::StateType::Random1QBasis;
-    ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
-    ecm.run();
-    std::cout << ecm.toString() << std::endl;
-    EXPECT_TRUE(ecm.getResults().consideredEquivalent());
+  config.simulation.stateType = ec::StateType::Random1QBasis;
+  ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
+  ecm.run();
+  std::cout << ecm.toString() << std::endl;
+  EXPECT_TRUE(ecm.getResults().consideredEquivalent());
 
-    qcAlternative.import("./circuits/test/test_erroneous.real");
-    ec::EquivalenceCheckingManager ecm2(qcOriginal, qcAlternative, config);
-    ecm2.run();
-    std::cout << ecm2.toString() << std::endl;
-    EXPECT_FALSE(ecm2.getResults().consideredEquivalent());
+  qcAlternative.import("./circuits/test/test_erroneous.real");
+  ec::EquivalenceCheckingManager ecm2(qcOriginal, qcAlternative, config);
+  ecm2.run();
+  std::cout << ecm2.toString() << std::endl;
+  EXPECT_FALSE(ecm2.getResults().consideredEquivalent());
 }
 
 TEST_F(SimulationTest, GlobalStimuli) {
-    qcOriginal.import("./circuits/test/test_original.real");
-    qcAlternative.import("./circuits/test/test_alternative.real");
+  qcOriginal.import("./circuits/test/test_original.real");
+  qcAlternative.import("./circuits/test/test_alternative.real");
 
-    config.simulation.stateType = ec::StateType::Stabilizer;
-    ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
-    ecm.run();
-    std::cout << ecm.toString() << std::endl;
-    EXPECT_TRUE(ecm.getResults().consideredEquivalent());
+  config.simulation.stateType = ec::StateType::Stabilizer;
+  ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
+  ecm.run();
+  std::cout << ecm.toString() << std::endl;
+  EXPECT_TRUE(ecm.getResults().consideredEquivalent());
 
-    qcAlternative.import("./circuits/test/test_erroneous.real");
-    ec::EquivalenceCheckingManager ecm2(qcOriginal, qcAlternative, config);
-    ecm2.run();
-    std::cout << ecm2.toString() << std::endl;
-    EXPECT_FALSE(ecm2.getResults().consideredEquivalent());
+  qcAlternative.import("./circuits/test/test_erroneous.real");
+  ec::EquivalenceCheckingManager ecm2(qcOriginal, qcAlternative, config);
+  ecm2.run();
+  std::cout << ecm2.toString() << std::endl;
+  EXPECT_FALSE(ecm2.getResults().consideredEquivalent());
 }
 
 TEST_F(SimulationTest, ClassicalStimuliParallel) {
-    config.execution.parallel = true;
-    qcOriginal.import("./circuits/test/test_original.real");
-    qcAlternative.import("./circuits/test/test_alternative.real");
+  config.execution.parallel = true;
+  qcOriginal.import("./circuits/test/test_original.real");
+  qcAlternative.import("./circuits/test/test_alternative.real");
 
-    config.simulation.stateType = ec::StateType::ComputationalBasis;
-    ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
-    ecm.run();
-    std::cout << ecm.toString() << std::endl;
-    EXPECT_TRUE(ecm.getResults().consideredEquivalent());
+  config.simulation.stateType = ec::StateType::ComputationalBasis;
+  ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
+  ecm.run();
+  std::cout << ecm.toString() << std::endl;
+  EXPECT_TRUE(ecm.getResults().consideredEquivalent());
 
-    qcAlternative.import("./circuits/test/test_erroneous.real");
-    ec::EquivalenceCheckingManager ecm2(qcOriginal, qcAlternative, config);
-    ecm2.run();
-    std::cout << ecm2.toString() << std::endl;
-    EXPECT_FALSE(ecm2.getResults().consideredEquivalent());
+  qcAlternative.import("./circuits/test/test_erroneous.real");
+  ec::EquivalenceCheckingManager ecm2(qcOriginal, qcAlternative, config);
+  ecm2.run();
+  std::cout << ecm2.toString() << std::endl;
+  EXPECT_FALSE(ecm2.getResults().consideredEquivalent());
 }
 
 TEST_F(SimulationTest, LocalStimuliParallel) {
-    config.execution.parallel = true;
-    qcOriginal.import("./circuits/test/test_original.real");
-    qcAlternative.import("./circuits/test/test_alternative.real");
+  config.execution.parallel = true;
+  qcOriginal.import("./circuits/test/test_original.real");
+  qcAlternative.import("./circuits/test/test_alternative.real");
 
-    config.simulation.stateType = ec::StateType::Random1QBasis;
-    ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
-    ecm.run();
-    std::cout << ecm.toString() << std::endl;
-    EXPECT_TRUE(ecm.getResults().consideredEquivalent());
+  config.simulation.stateType = ec::StateType::Random1QBasis;
+  ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
+  ecm.run();
+  std::cout << ecm.toString() << std::endl;
+  EXPECT_TRUE(ecm.getResults().consideredEquivalent());
 
-    qcAlternative.import("./circuits/test/test_erroneous.real");
-    ec::EquivalenceCheckingManager ecm2(qcOriginal, qcAlternative, config);
-    ecm2.run();
-    std::cout << ecm2.toString() << std::endl;
-    EXPECT_FALSE(ecm2.getResults().consideredEquivalent());
+  qcAlternative.import("./circuits/test/test_erroneous.real");
+  ec::EquivalenceCheckingManager ecm2(qcOriginal, qcAlternative, config);
+  ecm2.run();
+  std::cout << ecm2.toString() << std::endl;
+  EXPECT_FALSE(ecm2.getResults().consideredEquivalent());
 }
 
 TEST_F(SimulationTest, GlobalStimuliParallel) {
-    config.execution.parallel = true;
-    qcOriginal.import("./circuits/test/test_original.real");
-    qcAlternative.import("./circuits/test/test_alternative.real");
+  config.execution.parallel = true;
+  qcOriginal.import("./circuits/test/test_original.real");
+  qcAlternative.import("./circuits/test/test_alternative.real");
 
-    config.simulation.stateType = ec::StateType::Stabilizer;
-    ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
-    ecm.run();
-    std::cout << ecm.toString() << std::endl;
-    EXPECT_TRUE(ecm.getResults().consideredEquivalent());
+  config.simulation.stateType = ec::StateType::Stabilizer;
+  ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
+  ecm.run();
+  std::cout << ecm.toString() << std::endl;
+  EXPECT_TRUE(ecm.getResults().consideredEquivalent());
 
-    qcAlternative.import("./circuits/test/test_erroneous.real");
-    ec::EquivalenceCheckingManager ecm2(qcOriginal, qcAlternative, config);
-    ecm2.run();
-    std::cout << ecm2.toString() << std::endl;
-    EXPECT_FALSE(ecm2.getResults().consideredEquivalent());
+  qcAlternative.import("./circuits/test/test_erroneous.real");
+  ec::EquivalenceCheckingManager ecm2(qcOriginal, qcAlternative, config);
+  ecm2.run();
+  std::cout << ecm2.toString() << std::endl;
+  EXPECT_FALSE(ecm2.getResults().consideredEquivalent());
 }

--- a/test/test_equality.cpp
+++ b/test/test_equality.cpp
@@ -1,6 +1,6 @@
 //
-// This file is part of MQT QCEC library which is released under the MIT license.
-// See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
 #include "EquivalenceCheckingManager.hpp"
@@ -12,114 +12,116 @@
 
 using namespace dd::literals;
 
-class EqualityTest: public testing::Test {
-    void SetUp() override {
-        qc1                                       = qc::QuantumComputation(nqubits);
-        qc2                                       = qc::QuantumComputation(nqubits);
-        config.optimizations.fuseSingleQubitGates = false;
-        config.optimizations.reorderOperations    = false;
-        config.optimizations.reconstructSWAPs     = false;
+class EqualityTest : public testing::Test {
+  void SetUp() override {
+    qc1                                       = qc::QuantumComputation(nqubits);
+    qc2                                       = qc::QuantumComputation(nqubits);
+    config.optimizations.fuseSingleQubitGates = false;
+    config.optimizations.reorderOperations    = false;
+    config.optimizations.reconstructSWAPs     = false;
 
-        config.execution.runSimulationChecker   = false;
-        config.execution.runAlternatingChecker  = false;
-        config.execution.runConstructionChecker = false;
-        config.execution.runZXChecker           = false;
-    }
+    config.execution.runSimulationChecker   = false;
+    config.execution.runAlternatingChecker  = false;
+    config.execution.runConstructionChecker = false;
+    config.execution.runZXChecker           = false;
+  }
 
 protected:
-    dd::QubitCount         nqubits = 1U;
-    qc::QuantumComputation qc1;
-    qc::QuantumComputation qc2;
-    ec::Configuration      config{};
+  dd::QubitCount         nqubits = 1U;
+  qc::QuantumComputation qc1;
+  qc::QuantumComputation qc2;
+  ec::Configuration      config{};
 };
 
 TEST_F(EqualityTest, GlobalPhase) {
-    qc1.x(0);
-    qc2.x(0);
+  qc1.x(0);
+  qc2.x(0);
 
-    // add a global phase of -1
-    qc2.z(0);
-    qc2.x(0);
-    qc2.z(0);
-    qc2.x(0);
+  // add a global phase of -1
+  qc2.z(0);
+  qc2.x(0);
+  qc2.z(0);
+  qc2.x(0);
 
-    config.execution.runAlternatingChecker = true;
-    ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
-    ecm.run();
-    EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::EquivalentUpToGlobalPhase);
+  config.execution.runAlternatingChecker = true;
+  ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
+  ecm.run();
+  EXPECT_EQ(ecm.equivalence(),
+            ec::EquivalenceCriterion::EquivalentUpToGlobalPhase);
 }
 
 TEST_F(EqualityTest, CloseButNotEqualAlternating) {
-    qc1.x(0);
+  qc1.x(0);
 
-    qc2.x(0);
-    qc2.phase(0, dd::PI / 1024.);
+  qc2.x(0);
+  qc2.phase(0, dd::PI / 1024.);
 
-    config.functionality.traceThreshold    = 1e-2;
-    config.execution.runAlternatingChecker = true;
-    ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
-    ecm.run();
-    std::cout << ecm << std::endl;
-    EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::Equivalent);
+  config.functionality.traceThreshold    = 1e-2;
+  config.execution.runAlternatingChecker = true;
+  ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
+  ecm.run();
+  std::cout << ecm << std::endl;
+  EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::Equivalent);
 }
 
 TEST_F(EqualityTest, CloseButNotEqualConstruction) {
-    qc1.x(0);
+  qc1.x(0);
 
-    qc2.x(0);
-    qc2.phase(0, dd::PI / 1024.);
+  qc2.x(0);
+  qc2.phase(0, dd::PI / 1024.);
 
-    config.functionality.traceThreshold     = 1e-2;
-    config.execution.runConstructionChecker = true;
-    ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
-    ecm.run();
-    std::cout << ecm << std::endl;
-    EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::Equivalent);
+  config.functionality.traceThreshold     = 1e-2;
+  config.execution.runConstructionChecker = true;
+  ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
+  ecm.run();
+  std::cout << ecm << std::endl;
+  EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::Equivalent);
 }
 
 TEST_F(EqualityTest, CloseButNotEqualAlternatingGlobalPhase) {
-    qc1.x(0);
+  qc1.x(0);
 
-    qc2.x(0);
-    qc2.phase(0, dd::PI / 1024.);
-    // add a global phase of -1
-    qc2.z(0);
-    qc2.x(0);
-    qc2.z(0);
-    qc2.x(0);
+  qc2.x(0);
+  qc2.phase(0, dd::PI / 1024.);
+  // add a global phase of -1
+  qc2.z(0);
+  qc2.x(0);
+  qc2.z(0);
+  qc2.x(0);
 
-    config.functionality.traceThreshold    = 1e-2;
-    config.execution.runAlternatingChecker = true;
-    ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
-    ecm.run();
-    std::cout << ecm << std::endl;
-    EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::EquivalentUpToGlobalPhase);
+  config.functionality.traceThreshold    = 1e-2;
+  config.execution.runAlternatingChecker = true;
+  ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
+  ecm.run();
+  std::cout << ecm << std::endl;
+  EXPECT_EQ(ecm.equivalence(),
+            ec::EquivalenceCriterion::EquivalentUpToGlobalPhase);
 }
 
 TEST_F(EqualityTest, CloseButNotEqualSimulation) {
-    qc1.h(0);
+  qc1.h(0);
 
-    qc2.h(0);
-    qc2.phase(0, dd::PI / 1024.);
+  qc2.h(0);
+  qc2.phase(0, dd::PI / 1024.);
 
-    config.simulation.fidelityThreshold   = 1e-2;
-    config.execution.runSimulationChecker = true;
-    ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
-    ecm.run();
-    std::cout << ecm << std::endl;
-    EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::ProbablyEquivalent);
+  config.simulation.fidelityThreshold   = 1e-2;
+  config.execution.runSimulationChecker = true;
+  ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
+  ecm.run();
+  std::cout << ecm << std::endl;
+  EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::ProbablyEquivalent);
 }
 
 TEST_F(EqualityTest, SimulationMoreThan64Qubits) {
-    qc1 = qc::QuantumComputation(65U);
-    qc1.h(0);
-    for (auto i = 0U; i < 64U; ++i) {
-        qc1.x(static_cast<dd::Qubit>(i + 1), 0_pc);
-    }
-    qc2                                   = qc1.clone();
-    config.execution.runSimulationChecker = true;
-    ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
-    ecm.run();
-    std::cout << ecm << std::endl;
-    EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::ProbablyEquivalent);
+  qc1 = qc::QuantumComputation(65U);
+  qc1.h(0);
+  for (auto i = 0U; i < 64U; ++i) {
+    qc1.x(static_cast<dd::Qubit>(i + 1), 0_pc);
+  }
+  qc2                                   = qc1.clone();
+  config.execution.runSimulationChecker = true;
+  ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
+  ecm.run();
+  std::cout << ecm << std::endl;
+  EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::ProbablyEquivalent);
 }

--- a/test/test_gate_cost_application_scheme.cpp
+++ b/test/test_gate_cost_application_scheme.cpp
@@ -1,6 +1,6 @@
 //
-// This file is part of MQT QCEC library which is released under the MIT license.
-// See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
 #include "EquivalenceCheckingManager.hpp"
@@ -13,69 +13,72 @@
 
 using namespace dd::literals;
 
-class GateCostApplicationSchemeTest: public testing::Test {
-    void SetUp() override {
-        dd = std::make_unique<dd::Package<>>(nqubits);
-        qc = qc::QuantumComputation(nqubits);
-    }
+class GateCostApplicationSchemeTest : public testing::Test {
+  void SetUp() override {
+    dd = std::make_unique<dd::Package<>>(nqubits);
+    qc = qc::QuantumComputation(nqubits);
+  }
 
 protected:
-    dd::QubitCount                 nqubits = 3U;
-    std::unique_ptr<dd::Package<>> dd;
-    qc::QuantumComputation         qc;
+  dd::QubitCount                 nqubits = 3U;
+  std::unique_ptr<dd::Package<>> dd;
+  qc::QuantumComputation         qc;
 };
 
 TEST_F(GateCostApplicationSchemeTest, SchemeFromProfile) {
-    std::string   filename = "simple.profile";
-    std::ofstream ofs(filename);
+  std::string   filename = "simple.profile";
+  std::ofstream ofs(filename);
 
-    // create a very simple profile that just specifies that a Toffoli corresponds to 15 gates
-    ofs << "x 2 15\n";
-    ofs.close();
+  // create a very simple profile that just specifies that a Toffoli corresponds
+  // to 15 gates
+  ofs << "x 2 15\n";
+  ofs.close();
 
-    // apply Toffoli gate
-    qc.x(0, {1_pc, 2_pc});
+  // apply Toffoli gate
+  qc.x(0, {1_pc, 2_pc});
 
-    auto tm = ec::TaskManager<qc::MatrixDD>(qc, dd);
+  auto tm = ec::TaskManager<qc::MatrixDD>(qc, dd);
 
-    auto scheme = ec::GateCostApplicationScheme(tm, tm, filename);
+  auto scheme = ec::GateCostApplicationScheme(tm, tm, filename);
 
-    const auto [left, right] = scheme();
+  const auto [left, right] = scheme();
 
-    EXPECT_EQ(left, 1U);
-    EXPECT_EQ(right, 15U);
+  EXPECT_EQ(left, 1U);
+  EXPECT_EQ(right, 15U);
 
-    ec::Configuration config{};
-    config.application.profile           = filename;
-    config.application.alternatingScheme = ec::ApplicationSchemeType::GateCost;
-    ec::EquivalenceCheckingManager ecm(qc, qc, config);
-    ecm.run();
-    EXPECT_TRUE(ecm.getResults().consideredEquivalent());
-    std::cout << ecm.toString() << std::endl;
+  ec::Configuration config{};
+  config.application.profile           = filename;
+  config.application.alternatingScheme = ec::ApplicationSchemeType::GateCost;
+  ec::EquivalenceCheckingManager ecm(qc, qc, config);
+  ecm.run();
+  EXPECT_TRUE(ecm.getResults().consideredEquivalent());
+  std::cout << ecm.toString() << std::endl;
 }
 
 TEST_F(GateCostApplicationSchemeTest, iSWAP) {
-    qc.iswap(0, 1);
+  qc.iswap(0, 1);
 
-    auto tm = ec::TaskManager<qc::MatrixDD>(qc, dd);
+  auto tm = ec::TaskManager<qc::MatrixDD>(qc, dd);
 
-    auto scheme = ec::GateCostApplicationScheme(tm, tm, &ec::LegacyIBMCostFunction);
+  auto scheme =
+      ec::GateCostApplicationScheme(tm, tm, &ec::LegacyIBMCostFunction);
 
-    const auto [left, right] = scheme();
+  const auto [left, right] = scheme();
 
-    EXPECT_EQ(left, 1U);
-    EXPECT_EQ(right, 6U);
+  EXPECT_EQ(left, 1U);
+  EXPECT_EQ(right, 6U);
 }
 
 TEST_F(GateCostApplicationSchemeTest, Peres) {
-    qc.peres(1, 2, 0_pc);
+  qc.peres(1, 2, 0_pc);
 
-    auto tm = ec::TaskManager<qc::MatrixDD>(qc, dd);
+  auto tm = ec::TaskManager<qc::MatrixDD>(qc, dd);
 
-    auto scheme = ec::GateCostApplicationScheme(tm, tm, &ec::LegacyIBMCostFunction);
+  auto scheme =
+      ec::GateCostApplicationScheme(tm, tm, &ec::LegacyIBMCostFunction);
 
-    const auto [left, right] = scheme();
+  const auto [left, right] = scheme();
 
-    EXPECT_EQ(left, 1U);
-    EXPECT_EQ(right, 15U);
+  EXPECT_EQ(left, 1U);
+  EXPECT_EQ(right, 15U);
 }

--- a/test/test_simple_circuit_identities.cpp
+++ b/test/test_simple_circuit_identities.cpp
@@ -1,6 +1,6 @@
 //
-// This file is part of MQT QCEC library which is released under the MIT license.
-// See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
 #include "EquivalenceCheckingManager.hpp"
@@ -11,146 +11,172 @@
 #include <sstream>
 #include <string>
 
-class SimpleCircuitIdentitiesTest: public testing::TestWithParam<std::pair<std::string, std::pair<std::string, std::string>>> {
+class SimpleCircuitIdentitiesTest
+    : public testing::TestWithParam<
+          std::pair<std::string, std::pair<std::string, std::string>>> {
 protected:
-    qc::QuantumComputation qcOriginal;
-    qc::QuantumComputation qcAlternative;
-    ec::Configuration      config{};
+  qc::QuantumComputation qcOriginal;
+  qc::QuantumComputation qcAlternative;
+  ec::Configuration      config{};
 
-    std::unique_ptr<ec::EquivalenceCheckingManager> ecm{};
+  std::unique_ptr<ec::EquivalenceCheckingManager> ecm{};
 
-    void SetUp() override {
-        const auto [circ1, circ2] = GetParam().second;
-        std::stringstream ss1{circ1};
-        qcOriginal.import(ss1, qc::OpenQASM);
-        std::stringstream ss2{circ2};
-        qcAlternative.import(ss2, qc::OpenQASM);
+  void SetUp() override {
+    const auto [circ1, circ2] = GetParam().second;
+    std::stringstream ss1{circ1};
+    qcOriginal.import(ss1, qc::OpenQASM);
+    std::stringstream ss2{circ2};
+    qcAlternative.import(ss2, qc::OpenQASM);
 
-        config.optimizations.reconstructSWAPs     = false;
-        config.optimizations.fuseSingleQubitGates = false;
-        config.optimizations.reorderOperations    = false;
-        config.execution.runZXChecker             = true;
-        EXPECT_NO_THROW(ecm = std::make_unique<ec::EquivalenceCheckingManager>(qcOriginal, qcAlternative, config););
-    }
+    config.optimizations.reconstructSWAPs     = false;
+    config.optimizations.fuseSingleQubitGates = false;
+    config.optimizations.reorderOperations    = false;
+    config.execution.runZXChecker             = true;
+    EXPECT_NO_THROW(ecm = std::make_unique<ec::EquivalenceCheckingManager>(
+                        qcOriginal, qcAlternative, config););
+  }
 
-    void TearDown() override {
-        std::cout << ecm->toString() << std::endl;
-    }
+  void TearDown() override { std::cout << ecm->toString() << std::endl; }
 };
 
-INSTANTIATE_TEST_SUITE_P(TestCircuits, SimpleCircuitIdentitiesTest,
-                         testing::Values(
-                             std::pair{"Reverse_CNOT_Direction",
-                                       std::pair{"OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[2];\ncx q[0], q[1];\n",
-                                                 "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[2];\nh q[0]; h q[1]; cx q[1], q[0]; h q[0]; h q[1];\n"}},
-                             std::pair{"T_T_is_S",
-                                       std::pair{"OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[1];\nt q[0]; t q[0];\n",
-                                                 "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[1];\ns q[0];\n"}},
-                             std::pair{"Sdag_from_Clifford",
-                                       std::pair{"OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[1];\nsdg q[0];\n",
-                                                 "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[1];\ns q[0]; s q[0]; s q[0];\n"}},
-                             std::pair{"X_from_Clifford",
-                                       std::pair{"OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[1];\nx q[0];\n",
-                                                 "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[1];\nh q[0]; s q[0]; s q[0]; h q[0];\n"}},
-                             std::pair{"CZ_from_CX_and_H",
-                                       std::pair{"OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[2];\ncz q[0], q[1];\n",
-                                                 "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[2];\nh q[1]; cx q[0], q[1]; h q[1];\n"}},
-                             std::pair{"CS_from_CX_and_T",
-                                       std::pair{"OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[2];\ncs q[0], q[1];\n",
-                                                 "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[2];\nt q[0]; cx q[0], q[1]; tdg q[1]; cx q[0], q[1]; t q[1];\n"}},
-                             std::pair{"iSWAP_decomposition",
-                                       std::pair{"OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[2];\niswap q[0], q[1];\n",
-                                                 "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[2];\ns q[0]; s q[1]; h q[0]; cx q[0],q[1]; cx q[1],q[0]; h q[1];\n"}},
-                             std::pair{"Global_Phase",
-                                       std::pair{"OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[1];\nz q[0]; x q[0]; z q[0];\n",
-                                                 "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[1];\n x q[0];\n"}}),
-                         [](const testing::TestParamInfo<SimpleCircuitIdentitiesTest::ParamType>& info) {
-                             std::stringstream ss{};
-                             ss << info.param.first;
-                             return ss.str(); });
+INSTANTIATE_TEST_SUITE_P(
+    TestCircuits, SimpleCircuitIdentitiesTest,
+    testing::Values(
+        std::pair{
+            "Reverse_CNOT_Direction",
+            std::pair{"OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[2];\ncx "
+                      "q[0], q[1];\n",
+                      "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[2];\nh "
+                      "q[0]; h q[1]; cx q[1], q[0]; h q[0]; h q[1];\n"}},
+        std::pair{"T_T_is_S",
+                  std::pair{"OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg "
+                            "q[1];\nt q[0]; t q[0];\n",
+                            "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg "
+                            "q[1];\ns q[0];\n"}},
+        std::pair{"Sdag_from_Clifford",
+                  std::pair{"OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg "
+                            "q[1];\nsdg q[0];\n",
+                            "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg "
+                            "q[1];\ns q[0]; s q[0]; s q[0];\n"}},
+        std::pair{
+            "X_from_Clifford",
+            std::pair{
+                "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[1];\nx q[0];\n",
+                "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[1];\nh q[0]; s "
+                "q[0]; s q[0]; h q[0];\n"}},
+        std::pair{"CZ_from_CX_and_H",
+                  std::pair{"OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg "
+                            "q[2];\ncz q[0], q[1];\n",
+                            "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg "
+                            "q[2];\nh q[1]; cx q[0], q[1]; h q[1];\n"}},
+        std::pair{
+            "CS_from_CX_and_T",
+            std::pair{
+                "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[2];\ncs q[0], "
+                "q[1];\n",
+                "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[2];\nt q[0]; "
+                "cx q[0], q[1]; tdg q[1]; cx q[0], q[1]; t q[1];\n"}},
+        std::pair{
+            "iSWAP_decomposition",
+            std::pair{
+                "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[2];\niswap "
+                "q[0], q[1];\n",
+                "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[2];\ns q[0]; s "
+                "q[1]; h q[0]; cx q[0],q[1]; cx q[1],q[0]; h q[1];\n"}},
+        std::pair{"Global_Phase",
+                  std::pair{"OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg "
+                            "q[1];\nz q[0]; x q[0]; z q[0];\n",
+                            "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg "
+                            "q[1];\n x q[0];\n"}}),
+    [](const testing::TestParamInfo<SimpleCircuitIdentitiesTest::ParamType>&
+           info) {
+      std::stringstream ss{};
+      ss << info.param.first;
+      return ss.str();
+    });
 
 TEST_P(SimpleCircuitIdentitiesTest, DefaultOptionsParallel) {
-    EXPECT_NO_THROW(ecm->run(););
+  EXPECT_NO_THROW(ecm->run(););
 
-    EXPECT_TRUE(ecm->getResults().consideredEquivalent());
+  EXPECT_TRUE(ecm->getResults().consideredEquivalent());
 }
 
 TEST_P(SimpleCircuitIdentitiesTest, DefaultOptionsSequential) {
-    ecm->setParallel(false);
+  ecm->setParallel(false);
 
-    EXPECT_NO_THROW(ecm->run(););
+  EXPECT_NO_THROW(ecm->run(););
 
-    EXPECT_TRUE(ecm->getResults().consideredEquivalent());
+  EXPECT_TRUE(ecm->getResults().consideredEquivalent());
 }
 
 TEST_P(SimpleCircuitIdentitiesTest, DefaultOptionsOnlySimulation) {
-    ecm->setAlternatingChecker(false);
-    ecm->setConstructionChecker(false);
-    ecm->setZXChecker(false);
+  ecm->setAlternatingChecker(false);
+  ecm->setConstructionChecker(false);
+  ecm->setZXChecker(false);
 
-    EXPECT_NO_THROW(ecm->run(););
+  EXPECT_NO_THROW(ecm->run(););
 
-    EXPECT_TRUE(ecm->getResults().consideredEquivalent());
+  EXPECT_TRUE(ecm->getResults().consideredEquivalent());
 }
 
 TEST_P(SimpleCircuitIdentitiesTest, DefaultOptionsOnlyConstruction) {
-    ecm->setAlternatingChecker(false);
-    ecm->setSimulationChecker(false);
-    ecm->setConstructionChecker(true);
-    ecm->setZXChecker(false);
+  ecm->setAlternatingChecker(false);
+  ecm->setSimulationChecker(false);
+  ecm->setConstructionChecker(true);
+  ecm->setZXChecker(false);
 
-    EXPECT_NO_THROW(ecm->run(););
+  EXPECT_NO_THROW(ecm->run(););
 
-    EXPECT_TRUE(ecm->getResults().consideredEquivalent());
+  EXPECT_TRUE(ecm->getResults().consideredEquivalent());
 }
 
 TEST_P(SimpleCircuitIdentitiesTest, DefaultOptionsOnlyZX) {
-    ecm->setAlternatingChecker(false);
-    ecm->setSimulationChecker(false);
-    ecm->setConstructionChecker(false);
-    ecm->setZXChecker(true);
+  ecm->setAlternatingChecker(false);
+  ecm->setSimulationChecker(false);
+  ecm->setConstructionChecker(false);
+  ecm->setZXChecker(true);
 
-    EXPECT_NO_THROW(ecm->run(););
-    EXPECT_TRUE(ecm->getResults().consideredEquivalent());
+  EXPECT_NO_THROW(ecm->run(););
+  EXPECT_TRUE(ecm->getResults().consideredEquivalent());
 }
 
 TEST_P(SimpleCircuitIdentitiesTest, SequentialZX) {
-    ecm->setAlternatingChecker(false);
-    ecm->setSimulationChecker(false);
-    ecm->setConstructionChecker(false);
-    ecm->setZXChecker(true);
-    ecm->setParallel(false);
+  ecm->setAlternatingChecker(false);
+  ecm->setSimulationChecker(false);
+  ecm->setConstructionChecker(false);
+  ecm->setZXChecker(true);
+  ecm->setParallel(false);
 
-    EXPECT_NO_THROW(ecm->run(););
-    EXPECT_TRUE(ecm->getResults().consideredEquivalent());
+  EXPECT_NO_THROW(ecm->run(););
+  EXPECT_TRUE(ecm->getResults().consideredEquivalent());
 }
 
 TEST_P(SimpleCircuitIdentitiesTest, GateCostApplicationScheme) {
-    ecm->setSimulationChecker(false);
-    ecm->setAlternatingApplicationScheme(ec::ApplicationSchemeType::GateCost);
-    ecm->setGateCostFunction(&ec::LegacyIBMCostFunction);
-    EXPECT_NO_THROW(ecm->run(););
+  ecm->setSimulationChecker(false);
+  ecm->setAlternatingApplicationScheme(ec::ApplicationSchemeType::GateCost);
+  ecm->setGateCostFunction(&ec::LegacyIBMCostFunction);
+  EXPECT_NO_THROW(ecm->run(););
 
-    EXPECT_TRUE(ecm->getResults().consideredEquivalent());
+  EXPECT_TRUE(ecm->getResults().consideredEquivalent());
 }
 
 TEST_P(SimpleCircuitIdentitiesTest, ReorderingOperations) {
-    ecm->reorderOperations();
-    EXPECT_NO_THROW(ecm->run(););
+  ecm->reorderOperations();
+  EXPECT_NO_THROW(ecm->run(););
 
-    EXPECT_TRUE(ecm->getResults().consideredEquivalent());
+  EXPECT_TRUE(ecm->getResults().consideredEquivalent());
 }
 
 TEST_P(SimpleCircuitIdentitiesTest, FuseSingleQubitGates) {
-    ecm->fuseSingleQubitGates();
-    EXPECT_NO_THROW(ecm->run(););
+  ecm->fuseSingleQubitGates();
+  EXPECT_NO_THROW(ecm->run(););
 
-    EXPECT_TRUE(ecm->getResults().consideredEquivalent());
+  EXPECT_TRUE(ecm->getResults().consideredEquivalent());
 }
 
 TEST_P(SimpleCircuitIdentitiesTest, ReconstructSWAPs) {
-    ecm->reconstructSWAPs();
-    EXPECT_NO_THROW(ecm->run(););
+  ecm->reconstructSWAPs();
+  EXPECT_NO_THROW(ecm->run(););
 
-    EXPECT_TRUE(ecm->getResults().consideredEquivalent());
+  EXPECT_TRUE(ecm->getResults().consideredEquivalent());
 }

--- a/test/test_zx.cpp
+++ b/test/test_zx.cpp
@@ -1,6 +1,6 @@
 //
-// This file is part of MQT QCEC library which is released under the MIT license.
-// See file README.md or go to https://www.cda.cit.tum.de/research/quantum_verification/ for more information.
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
 #include "Definitions.hpp"
@@ -16,233 +16,250 @@
 #include <string>
 
 using namespace dd::literals;
-class ZXTest: public testing::TestWithParam<std::string> {
+class ZXTest : public testing::TestWithParam<std::string> {
 protected:
-    qc::QuantumComputation qcOriginal;
-    qc::QuantumComputation qcAlternative;
-    ec::Configuration      config{};
+  qc::QuantumComputation qcOriginal;
+  qc::QuantumComputation qcAlternative;
+  ec::Configuration      config{};
 
-    std::unique_ptr<ec::EquivalenceCheckingManager> ecm{};
+  std::unique_ptr<ec::EquivalenceCheckingManager> ecm{};
 
-    std::string testOriginal       = "./circuits/test/test.real";
-    std::string testAlternativeDir = "./circuits/test/";
+  std::string testOriginal       = "./circuits/test/test.real";
+  std::string testAlternativeDir = "./circuits/test/";
 
-    void SetUp() override {
-        config.execution.parallel               = true;
-        config.execution.runConstructionChecker = false;
-        config.execution.runAlternatingChecker  = false;
-        config.execution.runSimulationChecker   = false;
-        config.execution.runZXChecker           = true;
-    }
+  void SetUp() override {
+    config.execution.parallel               = true;
+    config.execution.runConstructionChecker = false;
+    config.execution.runAlternatingChecker  = false;
+    config.execution.runSimulationChecker   = false;
+    config.execution.runZXChecker           = true;
+  }
 
-    void TearDown() override {
-        std::cout << ecm->toString() << std::endl;
-    }
+  void TearDown() override { std::cout << ecm->toString() << std::endl; }
 };
 
-INSTANTIATE_TEST_SUITE_P(TestCircuits, ZXTest,
-                         testing::Values(
-                             "inputperm", "ancilla", "ancilla_inputperm", "swap",
-                             "outputperm", "ancilla_inputperm_outputperm",
-                             "optimizedswap", "ancilla_inputperm_outputperm_optimizedswap",
-                             "ancilla_inputperm_outputperm_optimizedswap2"),
-                         [](const testing::TestParamInfo<ZXTest::ParamType>& info) {
-			                 std::stringstream ss{};
-			                 ss << info.param;
-			                 return ss.str(); });
+INSTANTIATE_TEST_SUITE_P(
+    TestCircuits, ZXTest,
+    testing::Values("inputperm", "ancilla", "ancilla_inputperm", "swap",
+                    "outputperm", "ancilla_inputperm_outputperm",
+                    "optimizedswap",
+                    "ancilla_inputperm_outputperm_optimizedswap",
+                    "ancilla_inputperm_outputperm_optimizedswap2"),
+    [](const testing::TestParamInfo<ZXTest::ParamType>& info) {
+      std::stringstream ss{};
+      ss << info.param;
+      return ss.str();
+    });
 
 TEST_P(ZXTest, TestCircuits) {
-    qcOriginal.import(testOriginal);
-    qcAlternative.import(testAlternativeDir + "test_" + GetParam() + ".qasm");
-    ecm = std::make_unique<ec::EquivalenceCheckingManager>(qcOriginal, qcAlternative, config);
+  qcOriginal.import(testOriginal);
+  qcAlternative.import(testAlternativeDir + "test_" + GetParam() + ".qasm");
+  ecm = std::make_unique<ec::EquivalenceCheckingManager>(qcOriginal,
+                                                         qcAlternative, config);
 
-    ecm->run();
-    EXPECT_TRUE(ecm->getResults().consideredEquivalent());
+  ecm->run();
+  EXPECT_TRUE(ecm->getResults().consideredEquivalent());
 }
 
 TEST_F(ZXTest, NonEquivalent) {
-    qcOriginal.import(std::stringstream("OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[2];\ncx q[0], q[1];\n"), qc::OpenQASM);
-    qcAlternative.import(std::stringstream("OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[2];\nh q[0]; cx q[1], q[0]; h q[0]; h q[1];\n"), qc::OpenQASM);
-    ecm = std::make_unique<ec::EquivalenceCheckingManager>(qcOriginal, qcAlternative, config);
+  qcOriginal.import(
+      std::stringstream("OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg "
+                        "q[2];\ncx q[0], q[1];\n"),
+      qc::OpenQASM);
+  qcAlternative.import(
+      std::stringstream("OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[2];\nh "
+                        "q[0]; cx q[1], q[0]; h q[0]; h q[1];\n"),
+      qc::OpenQASM);
+  ecm = std::make_unique<ec::EquivalenceCheckingManager>(qcOriginal,
+                                                         qcAlternative, config);
 
-    ecm->run();
-    EXPECT_FALSE(ecm->getResults().consideredEquivalent());
+  ecm->run();
+  EXPECT_FALSE(ecm->getResults().consideredEquivalent());
 }
 
 TEST_F(ZXTest, Timeout) {
-    // construct large circuit
-    constexpr auto numLayers = 10000;
-    qcOriginal               = qc::QuantumComputation(2);
-    qcAlternative            = qc::QuantumComputation(2);
-    for (auto i = 0; i < numLayers; ++i) {
-        qcOriginal.x(0, 1_pc);
-        qcOriginal.h(0);
+  // construct large circuit
+  constexpr auto numLayers = 10000;
+  qcOriginal               = qc::QuantumComputation(2);
+  qcAlternative            = qc::QuantumComputation(2);
+  for (auto i = 0; i < numLayers; ++i) {
+    qcOriginal.x(0, 1_pc);
+    qcOriginal.h(0);
 
-        qcAlternative.x(0, 1_pc);
-        qcAlternative.h(0);
-    }
+    qcAlternative.x(0, 1_pc);
+    qcAlternative.h(0);
+  }
 
-    config.execution.timeout = 1s;
-    ecm                      = std::make_unique<ec::EquivalenceCheckingManager>(qcOriginal, qcAlternative, config);
+  config.execution.timeout = 1s;
+  ecm = std::make_unique<ec::EquivalenceCheckingManager>(qcOriginal,
+                                                         qcAlternative, config);
 
-    ecm->run();
-    EXPECT_EQ(ecm->getResults().equivalence, ec::EquivalenceCriterion::NoInformation);
+  ecm->run();
+  EXPECT_EQ(ecm->getResults().equivalence,
+            ec::EquivalenceCriterion::NoInformation);
 }
 
 TEST_F(ZXTest, CloseButNotEqual) {
-    qcOriginal = qc::QuantumComputation(1);
-    qcOriginal.x(0);
+  qcOriginal = qc::QuantumComputation(1);
+  qcOriginal.x(0);
 
-    qcAlternative = qc::QuantumComputation(1);
-    qcAlternative.x(0);
-    qcAlternative.phase(0, dd::PI / 1024.);
+  qcAlternative = qc::QuantumComputation(1);
+  qcAlternative.x(0);
+  qcAlternative.phase(0, dd::PI / 1024.);
 
-    config.functionality.traceThreshold = 1e-2;
+  config.functionality.traceThreshold = 1e-2;
 
-    ecm = std::make_unique<ec::EquivalenceCheckingManager>(qcOriginal, qcAlternative, config);
+  ecm = std::make_unique<ec::EquivalenceCheckingManager>(qcOriginal,
+                                                         qcAlternative, config);
 
-    ecm->run();
-    EXPECT_EQ(ecm->equivalence(), ec::EquivalenceCriterion::EquivalentUpToGlobalPhase);
+  ecm->run();
+  EXPECT_EQ(ecm->equivalence(),
+            ec::EquivalenceCriterion::EquivalentUpToGlobalPhase);
 }
 
 TEST_F(ZXTest, NotEqual) {
-    qcOriginal = qc::QuantumComputation(1);
-    qcOriginal.x(0);
+  qcOriginal = qc::QuantumComputation(1);
+  qcOriginal.x(0);
 
-    qcAlternative = qc::QuantumComputation(1);
-    qcAlternative.x(0);
-    qcAlternative.phase(0, dd::PI / 1024.);
+  qcAlternative = qc::QuantumComputation(1);
+  qcAlternative.x(0);
+  qcAlternative.phase(0, dd::PI / 1024.);
 
-    config.functionality.traceThreshold = 1e-9;
+  config.functionality.traceThreshold = 1e-9;
 
-    ecm = std::make_unique<ec::EquivalenceCheckingManager>(qcOriginal, qcAlternative, config);
-    ecm->run();
-    EXPECT_EQ(ecm->equivalence(), ec::EquivalenceCriterion::ProbablyNotEquivalent);
+  ecm = std::make_unique<ec::EquivalenceCheckingManager>(qcOriginal,
+                                                         qcAlternative, config);
+  ecm->run();
+  EXPECT_EQ(ecm->equivalence(),
+            ec::EquivalenceCriterion::ProbablyNotEquivalent);
 }
 
 TEST_F(ZXTest, PermutationMismatch) {
-    qcOriginal = qc::QuantumComputation(2);
-    qcOriginal.x(0, 1_pc);
+  qcOriginal = qc::QuantumComputation(2);
+  qcOriginal.x(0, 1_pc);
 
-    qcAlternative = qc::QuantumComputation(2);
-    qcAlternative.x(0, 1_pc);
+  qcAlternative = qc::QuantumComputation(2);
+  qcAlternative.x(0, 1_pc);
 
-    qcAlternative.outputPermutation[0] = 1;
-    qcAlternative.outputPermutation[1] = 0;
+  qcAlternative.outputPermutation[0] = 1;
+  qcAlternative.outputPermutation[1] = 0;
 
-    ecm = std::make_unique<ec::EquivalenceCheckingManager>(qcOriginal, qcAlternative, config);
-    ecm->run();
+  ecm = std::make_unique<ec::EquivalenceCheckingManager>(qcOriginal,
+                                                         qcAlternative, config);
+  ecm->run();
 
-    EXPECT_FALSE(ecm->getResults().consideredEquivalent());
+  EXPECT_FALSE(ecm->getResults().consideredEquivalent());
 }
 
 TEST_F(ZXTest, Permutation) {
-    auto qc1 = qc::QuantumComputation(2);
-    auto qc2 = qc::QuantumComputation(2);
-    qc1.x(0);
-    qc1.x(1);
-    qc2.x(0);
-    qc2.x(1);
-    qc::Permutation p;
-    p[0]                  = 1;
-    p[1]                  = 0;
-    qc1.initialLayout     = p;
-    qc1.outputPermutation = p;
+  auto qc1 = qc::QuantumComputation(2);
+  auto qc2 = qc::QuantumComputation(2);
+  qc1.x(0);
+  qc1.x(1);
+  qc2.x(0);
+  qc2.x(1);
+  qc::Permutation p;
+  p[0]                  = 1;
+  p[1]                  = 0;
+  qc1.initialLayout     = p;
+  qc1.outputPermutation = p;
 
-    ecm = std::make_unique<ec::EquivalenceCheckingManager>(qc1, qc2, config);
-    ecm->run();
+  ecm = std::make_unique<ec::EquivalenceCheckingManager>(qc1, qc2, config);
+  ecm->run();
 
-    EXPECT_TRUE(ecm->getResults().consideredEquivalent());
+  EXPECT_TRUE(ecm->getResults().consideredEquivalent());
 }
 
 TEST_F(ZXTest, Ancilla) {
-    auto qc1 = qc::QuantumComputation(1);
-    auto qc2 = qc::QuantumComputation(2);
+  auto qc1 = qc::QuantumComputation(1);
+  auto qc2 = qc::QuantumComputation(2);
 
-    qc1.i(0);
-    qc2.x(0, 1_pc);
-    qc2.setLogicalQubitAncillary(1);
+  qc1.i(0);
+  qc2.x(0, 1_pc);
+  qc2.setLogicalQubitAncillary(1);
 
-    ecm = std::make_unique<ec::EquivalenceCheckingManager>(qc1, qc2, config);
-    ecm->run();
+  ecm = std::make_unique<ec::EquivalenceCheckingManager>(qc1, qc2, config);
+  ecm->run();
 
-    EXPECT_TRUE(ecm->getResults().consideredEquivalent());
+  EXPECT_TRUE(ecm->getResults().consideredEquivalent());
 }
 
 TEST_F(ZXTest, ZXWrongAncilla) {
-    auto            qc1 = qc::QuantumComputation(1);
-    auto            qc2 = qc::QuantumComputation(2);
-    qc::Permutation p1{};
-    p1[0] = 0;
-    qc1.x(0);
-    qc2.x(0, 1_nc);
-    qc2.setLogicalQubitAncillary(1);
+  auto            qc1 = qc::QuantumComputation(1);
+  auto            qc2 = qc::QuantumComputation(2);
+  qc::Permutation p1{};
+  p1[0] = 0;
+  qc1.x(0);
+  qc2.x(0, 1_nc);
+  qc2.setLogicalQubitAncillary(1);
 
-    ecm = std::make_unique<ec::EquivalenceCheckingManager>(qc1, qc2, config);
-    ecm->run();
+  ecm = std::make_unique<ec::EquivalenceCheckingManager>(qc1, qc2, config);
+  ecm->run();
 
-    EXPECT_EQ(ecm->getResults().equivalence, ec::EquivalenceCriterion::NoInformation);
+  EXPECT_EQ(ecm->getResults().equivalence,
+            ec::EquivalenceCriterion::NoInformation);
 }
 
 TEST_F(ZXTest, ZXConfiguredForInvalidCircuitParallel) {
-    auto qc = qc::QuantumComputation(4);
-    qc.x(0, {1_pc, 2_pc, 3_pc});
+  auto qc = qc::QuantumComputation(4);
+  qc.x(0, {1_pc, 2_pc, 3_pc});
 
-    ecm = std::make_unique<ec::EquivalenceCheckingManager>(qc, qc, config);
-    ecm->run();
+  ecm = std::make_unique<ec::EquivalenceCheckingManager>(qc, qc, config);
+  ecm->run();
 
-    EXPECT_EQ(ecm->getResults().equivalence, ec::EquivalenceCriterion::NoInformation);
+  EXPECT_EQ(ecm->getResults().equivalence,
+            ec::EquivalenceCriterion::NoInformation);
 }
 
 TEST_F(ZXTest, ZXConfiguredForInvalidCircuitSequential) {
-    auto qc = qc::QuantumComputation(4);
-    qc.x(0, {1_pc, 2_pc, 3_pc});
+  auto qc = qc::QuantumComputation(4);
+  qc.x(0, {1_pc, 2_pc, 3_pc});
 
-    config.execution.parallel = false;
-    ecm                       = std::make_unique<ec::EquivalenceCheckingManager>(qc, qc, config);
-    ecm->run();
+  config.execution.parallel = false;
+  ecm = std::make_unique<ec::EquivalenceCheckingManager>(qc, qc, config);
+  ecm->run();
 
-    EXPECT_EQ(ecm->getResults().equivalence, ec::EquivalenceCriterion::NoInformation);
+  EXPECT_EQ(ecm->getResults().equivalence,
+            ec::EquivalenceCriterion::NoInformation);
 }
 
-class ZXTestCompFlow: public testing::TestWithParam<std::string> {
+class ZXTestCompFlow : public testing::TestWithParam<std::string> {
 protected:
-    qc::QuantumComputation qcOriginal;
-    qc::QuantumComputation qcTranspiled;
-    ec::Configuration      config{};
+  qc::QuantumComputation qcOriginal;
+  qc::QuantumComputation qcTranspiled;
+  ec::Configuration      config{};
 
-    std::unique_ptr<ec::EquivalenceCheckingManager> ecm{};
+  std::unique_ptr<ec::EquivalenceCheckingManager> ecm{};
 
-    std::string test_original_dir   = "./circuits/original/";
-    std::string test_transpiled_dir = "./circuits/transpiled/";
+  std::string test_original_dir   = "./circuits/original/";
+  std::string test_transpiled_dir = "./circuits/transpiled/";
 
-    void SetUp() override {
-        config.execution.parallel               = false;
-        config.execution.runConstructionChecker = false;
-        config.execution.runAlternatingChecker  = false;
-        config.execution.runSimulationChecker   = false;
-        config.execution.runZXChecker           = true;
+  void SetUp() override {
+    config.execution.parallel               = false;
+    config.execution.runConstructionChecker = false;
+    config.execution.runAlternatingChecker  = false;
+    config.execution.runSimulationChecker   = false;
+    config.execution.runZXChecker           = true;
 
-        qcOriginal.import(test_original_dir + GetParam() + ".real");
-        qcTranspiled.import(test_transpiled_dir + GetParam() + "_transpiled.qasm");
-    }
+    qcOriginal.import(test_original_dir + GetParam() + ".real");
+    qcTranspiled.import(test_transpiled_dir + GetParam() + "_transpiled.qasm");
+  }
 };
 
-INSTANTIATE_TEST_SUITE_P(ZXTestCompFlow, ZXTestCompFlow,
-                         testing::Values(
-                             "c2_181",
-                             "rd73_312",
-                             "sym9_317",
-                             "mod5adder_306",
-                             "rd84_313"),
-                         [](const testing::TestParamInfo<ZXTestCompFlow::ParamType>& info) {
-							 auto s = info.param;
-							 std::replace( s.begin(), s.end(), '-', '_');
-	                         return s; });
+INSTANTIATE_TEST_SUITE_P(
+    ZXTestCompFlow, ZXTestCompFlow,
+    testing::Values("c2_181", "rd73_312", "sym9_317", "mod5adder_306",
+                    "rd84_313"),
+    [](const testing::TestParamInfo<ZXTestCompFlow::ParamType>& info) {
+      auto s = info.param;
+      std::replace(s.begin(), s.end(), '-', '_');
+      return s;
+    });
 
 TEST_P(ZXTestCompFlow, EquivalenceCompilationFlow) {
-    ecm = std::make_unique<ec::EquivalenceCheckingManager>(qcOriginal, qcTranspiled, config);
-    ecm->run();
-    std::cout << ecm->toString() << std::endl;
-    EXPECT_TRUE(ecm->getResults().consideredEquivalent());
+  ecm = std::make_unique<ec::EquivalenceCheckingManager>(qcOriginal,
+                                                         qcTranspiled, config);
+  ecm->run();
+  std::cout << ecm->toString() << std::endl;
+  EXPECT_TRUE(ecm->getResults().consideredEquivalent());
 }


### PR DESCRIPTION
In order to establish clearer coding guidelines for the QCEC library, this PR adjusts the `clang-format` configuration to follow (most of) [LLVM's coding style](https://llvm.org/docs/CodingStandards.html) with regard to formatting. Major changes are:
 - employing a source code width limit of `80` characters (see https://llvm.org/docs/CodingStandards.html#source-code-width) in order to conveniently fit multiple windows side-by-side
 - changing indentation to `2` spaces (from `4`spaces) to conserve space
 - some (arbitrary) spacing, breaking, and indentation settings are dropped