### PR TITLE
⚡ Avoid vtable Copy

### DIFF
--- a/include/checker/EquivalenceChecker.hpp
+++ b/include/checker/EquivalenceChecker.hpp
@@ -34,10 +34,7 @@ public:
   }
   [[nodiscard]] double getRuntime() const noexcept { return runtime; }
 
-  virtual void json(nlohmann::json& j) const noexcept {
-    j["equivalence"] = toString(equivalence);
-    j["runtime"]     = getRuntime();
-  }
+  virtual void json(nlohmann::json& j) const noexcept;
 
   void signalDone() { done.store(true, std::memory_order_relaxed); }
   [[nodiscard]] auto isDone() const {

--- a/include/checker/dd/DDConstructionChecker.hpp
+++ b/include/checker/dd/DDConstructionChecker.hpp
@@ -25,10 +25,7 @@ public:
         this->configuration.application.constructionScheme);
   }
 
-  void json(nlohmann::json& j) const noexcept override {
-    DDEquivalenceChecker::json(j);
-    j["checker"] = "decision_diagram_construction";
-  }
+  void json(nlohmann::json& j) const noexcept override;
 
 private:
   void initializeTask(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,9 @@ add_library(${PROJECT_NAME}
 
             ${CMAKE_CURRENT_SOURCE_DIR}/EquivalenceCheckingManager.cpp
 
+            ${CMAKE_CURRENT_SOURCE_DIR}/checker/EquivalenceChecker.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/checker/dd/DDEquivalenceChecker.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/checker/dd/DDConstructionChecker.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/checker/dd/DDSimulationChecker.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/checker/dd/DDAlternatingChecker.cpp
 

--- a/src/checker/EquivalenceChecker.cpp
+++ b/src/checker/EquivalenceChecker.cpp
@@ -1,0 +1,14 @@
+//
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
+//
+
+#include "checker/EquivalenceChecker.hpp"
+
+// this function is mainly placed here in order to have an out-of-line
+// virtual method definition which avoids emitting the classe's vtable in
+// every translation unit.
+void ec::EquivalenceChecker::json(nlohmann::json& j) const noexcept {
+  j["equivalence"] = toString(equivalence);
+  j["runtime"]     = getRuntime();
+}

--- a/src/checker/dd/DDConstructionChecker.cpp
+++ b/src/checker/dd/DDConstructionChecker.cpp
@@ -1,0 +1,14 @@
+//
+// This file is part of the MQT QCEC library released under the MIT license.
+// See README.md or go to https://github.com/cda-tum/qcec for more information.
+//
+
+#include "checker/dd/DDConstructionChecker.hpp"
+
+// this function is mainly placed here in order to have an out-of-line
+// virtual method definition which avoids emitting the classe's vtable in
+// every translation unit.
+void ec::DDConstructionChecker::json(nlohmann::json& j) const noexcept {
+  DDEquivalenceChecker::json(j);
+  j["checker"] = "decision_diagram_construction";
+}


### PR DESCRIPTION
According to https://llvm.org/docs/CodingStandards.html#provide-a-virtual-method-anchor-for-classes-in-headers:

> If a class is defined in a header file and has a vtable (either it has virtual methods or it derives from classes with virtual methods), it must always have at least one out-of-line virtual method in the class. Without this, the compiler will copy the vtable and RTTI into every .o file that #includes the header, bloating .o file sizes and increasing link times.

This PR fixes such cases for the QCEC library.