### PR TITLE
🐛 Fix Potential Endless Loop

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -13,6 +13,7 @@ coverage:
     patch:
       default:
         threshold: 1%
+        target: 90%
 
 parsers:
   gcov:

--- a/mqt/qcec/bindings.cpp
+++ b/mqt/qcec/bindings.cpp
@@ -21,16 +21,16 @@ namespace py = pybind11;
 using namespace pybind11::literals;
 
 namespace ec {
-qc::QuantumComputation importCircuit(const py::object& circ) {
-  py::object quantumCircuit =
+static qc::QuantumComputation importCircuit(const py::object& circ) {
+  const py::object quantumCircuit =
       py::module::import("qiskit").attr("QuantumCircuit");
-  py::object pyQasmQobjExperiment =
+  const py::object pyQasmQobjExperiment =
       py::module::import("qiskit.qobj").attr("QasmQobjExperiment");
 
   auto qc = qc::QuantumComputation();
 
   if (py::isinstance<py::str>(circ)) {
-    auto&& file = circ.cast<std::string>();
+    const auto file = circ.cast<std::string>();
     qc.import(file);
   } else if (py::isinstance(circ, quantumCircuit)) {
     qc::qiskit::QuantumCircuit::import(qc, circ);
@@ -44,14 +44,14 @@ qc::QuantumComputation importCircuit(const py::object& circ) {
   return qc;
 }
 
-std::unique_ptr<EquivalenceCheckingManager>
+static std::unique_ptr<EquivalenceCheckingManager>
 createManagerFromConfiguration(const py::object& circ1, const py::object& circ2,
                                const Configuration& configuration) noexcept {
   qc::QuantumComputation qc1;
   try {
     qc1 = importCircuit(circ1);
   } catch (const std::exception& ex) {
-    std::cerr << "Could not import first circuit: " << ex.what() << std::endl;
+    std::cerr << "Could not import first circuit: " << ex.what() << "\n";
     return {};
   }
 
@@ -59,7 +59,7 @@ createManagerFromConfiguration(const py::object& circ1, const py::object& circ2,
   try {
     qc2 = importCircuit(circ2);
   } catch (const std::exception& ex) {
-    std::cerr << "Could not import second circuit: " << ex.what() << std::endl;
+    std::cerr << "Could not import second circuit: " << ex.what() << "\n";
     return {};
   }
 
@@ -68,24 +68,28 @@ createManagerFromConfiguration(const py::object& circ1, const py::object& circ2,
                                                         configuration);
   } catch (const std::exception& ex) {
     std::cerr << "Failed to construct equivalence checking manager: "
-              << ex.what() << std::endl;
+              << ex.what() << "\n";
     return {};
   }
 }
 
-std::unique_ptr<EquivalenceCheckingManager> createManagerFromOptions(
+static std::unique_ptr<EquivalenceCheckingManager> createManagerFromOptions(
     const py::object& circ1, const py::object& circ2,
     // Execution
-    dd::fp      numericalTolerance = dd::ComplexTable<>::tolerance(),
-    bool        parallel           = true,
-    std::size_t nthreads = std::max(2U, std::thread::hardware_concurrency()),
-    std::chrono::seconds timeout = 0s, bool runConstructionChecker = false,
-    bool runSimulationChecker = true, bool runAlternatingChecker = true,
-    bool runZXChecker = true,
+    const dd::fp      numericalTolerance = dd::ComplexTable<>::tolerance(),
+    const bool        parallel           = true,
+    const std::size_t nthreads           = std::max(2U,
+                                                    std::thread::hardware_concurrency()),
+    const std::chrono::seconds timeout   = 0s,
+    const bool                 runConstructionChecker = false,
+    const bool                 runSimulationChecker   = true,
+    const bool runAlternatingChecker = true, const bool runZXChecker = true,
     // Optimization
-    bool fixOutputPermutationMismatch = false, bool fuseSingleQubitGates = true,
-    bool reconstructSWAPs = true, bool removeDiagonalGatesBeforeMeasure = false,
-    bool transformDynamicCircuit = false, bool reorderOperations = true,
+    const bool fixOutputPermutationMismatch = false,
+    const bool fuseSingleQubitGates = true, const bool reconstructSWAPs = true,
+    const bool removeDiagonalGatesBeforeMeasure = false,
+    const bool transformDynamicCircuit          = false,
+    const bool reorderOperations                = true,
     // Application
     const ApplicationSchemeType& constructionScheme =
         ApplicationSchemeType::Proportional,
@@ -95,14 +99,16 @@ std::unique_ptr<EquivalenceCheckingManager> createManagerFromOptions(
         ApplicationSchemeType::Proportional,
     const std::string& profile = {},
     // Functionality
-    double traceThreshold = 1e-8,
+    const double traceThreshold = 1e-8,
     // Simulation
-    double           fidelityThreshold = 1e-8,
-    std::size_t      maxSims           = std::max(16U,
-                                                  std::thread::hardware_concurrency() - 2U),
-    const StateType& stateType         = StateType::ComputationalBasis,
-    std::size_t seed = 0U, bool storeCEXinput = false,
-    bool storeCEXoutput = false) {
+    const double fidelityThreshold = 1e-8,
+
+    const std::size_t maxSims   = std::max(16U,
+                                           std::thread::hardware_concurrency() -
+                                               2U),
+    const StateType&  stateType = StateType::ComputationalBasis,
+    const std::size_t seed = 0U, const bool storeCEXinput = false,
+    const bool storeCEXoutput = false) {
   Configuration configuration{};
   // Execution
   configuration.execution.numericalTolerance     = numericalTolerance;
@@ -150,10 +156,10 @@ std::unique_ptr<EquivalenceCheckingManager> createManagerFromOptions(
   return createManagerFromConfiguration(circ1, circ2, configuration);
 }
 
-ec::EquivalenceCheckingManager::Results
+static ec::EquivalenceCheckingManager::Results
 verify(const py::object& circ1, const py::object& circ2,
        const Configuration& configuration = Configuration()) {
-  auto ecm = createManagerFromConfiguration(circ1, circ2, configuration);
+  const auto ecm = createManagerFromConfiguration(circ1, circ2, configuration);
   ecm->run();
   return ecm->getResults();
 }
@@ -193,7 +199,7 @@ PYBIND11_MODULE(pyqcec, m) {
       }))
       .def(
           "__str__",
-          [](ApplicationSchemeType scheme) { return toString(scheme); },
+          [](const ApplicationSchemeType scheme) { return toString(scheme); },
           py::prepend());
   py::implicitly_convertible<std::string, ApplicationSchemeType>();
 
@@ -212,7 +218,7 @@ PYBIND11_MODULE(pyqcec, m) {
         return stateTypeFromString(str);
       }))
       .def(
-          "__str__", [](StateType type) { return toString(type); },
+          "__str__", [](const StateType type) { return toString(type); },
           py::prepend());
   py::implicitly_convertible<std::string, StateType>();
 
@@ -247,7 +253,8 @@ PYBIND11_MODULE(pyqcec, m) {
         return fromString(str);
       }))
       .def(
-          "__str__", [](EquivalenceCriterion crit) { return toString(crit); },
+          "__str__",
+          [](const EquivalenceCriterion crit) { return toString(crit); },
           py::prepend());
   py::implicitly_convertible<std::string, EquivalenceCriterion>();
 

--- a/src/EquivalenceCheckingManager.cpp
+++ b/src/EquivalenceCheckingManager.cpp
@@ -17,7 +17,7 @@ void EquivalenceCheckingManager::setupAncillariesAndGarbage() {
       qc1.getNqubits() > qc2.getNqubits() ? this->qc1 : this->qc2;
   auto& smallerCircuit =
       qc1.getNqubits() > qc2.getNqubits() ? this->qc2 : this->qc1;
-  dd::QubitCount qubitDifference =
+  const dd::QubitCount qubitDifference =
       largerCircuit.getNqubits() - smallerCircuit.getNqubits();
 
   std::vector<std::pair<dd::Qubit, dd::Qubit>> removed{};
@@ -27,7 +27,7 @@ void EquivalenceCheckingManager::setupAncillariesAndGarbage() {
   std::vector<bool> garbage(nqubits);
 
   for (dd::QubitCount i = 0; i < qubitDifference; ++i) {
-    auto logicalQubitIndex =
+    const auto logicalQubitIndex =
         qc::QuantumComputation::getHighestLogicalQubitIndex(
             largerCircuit.initialLayout);
     garbage[logicalQubitIndex] =
@@ -40,7 +40,8 @@ void EquivalenceCheckingManager::setupAncillariesAndGarbage() {
 
   // reverse iterate over the removed qubits and add them back into the larger
   // circuit as ancillary
-  for (auto it = removed.rbegin(); it != removed.rend(); ++it) {
+  const auto rend = removed.rend();
+  for (auto it = removed.rbegin(); it != rend; ++it) {
     largerCircuit.addAncillaryQubit(it->first, it->second);
     // restore garbage
     if (garbage[largerCircuit.getNqubits() - 1]) {
@@ -64,17 +65,18 @@ void EquivalenceCheckingManager::fixOutputPermutationMismatch() {
   auto&       largerGarbage = largerCircuit.garbage;
 
   for (const auto& [lPhysical, lLogical] : largerOutput) {
-    dd::Qubit outputQubitInLargerCircuit = lLogical;
-    dd::Qubit nout                       = 1;
+    const dd::Qubit outputQubitInLargerCircuit = lLogical;
+    dd::Qubit       nout                       = 1;
     for (dd::Qubit i = 0; i < outputQubitInLargerCircuit; ++i) {
       if (!largerGarbage[i]) {
         ++nout;
       }
     }
 
-    dd::QubitCount outcount        = nout;
-    bool           existsInSmaller = false;
-    for (dd::QubitCount i = 0; i < smallerCircuit.getNqubits(); ++i) {
+    auto       outcount        = static_cast<dd::QubitCount>(nout);
+    bool       existsInSmaller = false;
+    const auto nqubits         = smallerCircuit.getNqubits();
+    for (dd::QubitCount i = 0U; i < nqubits; ++i) {
       if (!smallerGarbage[i]) {
         --outcount;
       }
@@ -88,7 +90,7 @@ void EquivalenceCheckingManager::fixOutputPermutationMismatch() {
       continue;
     }
 
-    std::cerr << "Uncorrected mismatch in output qubits!" << std::endl;
+    std::cerr << "Uncorrected mismatch in output qubits!\n";
   }
 }
 
@@ -147,8 +149,7 @@ void EquivalenceCheckingManager::run() {
   results.equivalence = EquivalenceCriterion::NoInformation;
 
   if (!configuration.anythingToExecute()) {
-    std::clog << "Nothing to be executed. Check your configuration!"
-              << std::endl;
+    std::clog << "Nothing to be executed. Check your configuration!\n";
     return;
   }
 
@@ -187,8 +188,7 @@ EquivalenceCheckingManager::EquivalenceCheckingManager(
   if (this->qc1.getNqubitsWithoutAncillae() !=
       this->qc2.getNqubitsWithoutAncillae()) {
     std::clog << "[QCEC] Warning: circuits have different number of primary "
-                 "inputs! Proceed with caution!"
-              << std::endl;
+                 "inputs! Proceed with caution!\n";
   }
 
   // try to fix a potential mismatch in the output permutations of both circuits
@@ -225,7 +225,7 @@ void EquivalenceCheckingManager::checkSequential() {
     timeoutThread =
         std::thread([this, timeout = configuration.execution.timeout] {
           std::unique_lock doneLock(doneMutex);
-          auto             finished =
+          const auto       finished =
               doneCond.wait_for(doneLock, timeout, [this] { return done; });
           // if the thread has already finished within the timeout, nothing has
           // to be done
@@ -238,7 +238,7 @@ void EquivalenceCheckingManager::checkSequential() {
   if (configuration.execution.runSimulationChecker) {
     checkers.emplace_back(
         std::make_unique<DDSimulationChecker>(qc1, qc2, configuration));
-    auto* simulationChecker =
+    auto* const simulationChecker =
         dynamic_cast<DDSimulationChecker*>(checkers.back().get());
     while (results.startedSimulations < configuration.simulation.maxSims &&
            !done) {
@@ -255,8 +255,7 @@ void EquivalenceCheckingManager::checkSequential() {
       if (result == EquivalenceCriterion::NoInformation) {
         if (!done) {
           std::clog << "Simulation run returned without any information. "
-                       "Something probably went wrong. Exiting!"
-                    << std::endl;
+                       "Something probably went wrong. Exiting!\n";
         }
         return;
       }
@@ -344,8 +343,7 @@ void EquivalenceCheckingManager::checkSequential() {
       }
     } else if (configuration.onlyZXCheckerConfigured()) {
       std::clog << "Only ZX checker specified but one of the circuits contains "
-                   "operations not supported by this checker! Exiting!"
-                << std::endl;
+                   "operations not supported by this checker! Exiting!\n";
       checkers.clear();
       results.equivalence = EquivalenceCriterion::NoInformation;
       return;
@@ -373,8 +371,7 @@ void EquivalenceCheckingManager::checkParallel() {
       threadLimit != 0U && configuration.execution.nthreads > threadLimit) {
     std::clog
         << "Trying to use more threads than the underlying architecture claims "
-           "to support. Over-subscription might impact performance!"
-        << std::endl;
+           "to support. Over-subscription might impact performance!\n";
   }
 
   const auto maxThreads      = configuration.execution.nthreads;
@@ -442,8 +439,7 @@ void EquivalenceCheckingManager::checkParallel() {
       ++id;
     } else if (configuration.onlyZXCheckerConfigured()) {
       std::clog << "Only ZX checker specified but one of the circuits contains "
-                   "operations not supported by this checker! Exiting!"
-                << std::endl;
+                   "operations not supported by this checker! Exiting!\n";
       checkers.clear();
       results.equivalence = EquivalenceCriterion::NoInformation;
       done                = true;
@@ -459,9 +455,10 @@ void EquivalenceCheckingManager::checkParallel() {
       threads.emplace_back([this, &queue, id] {
         checkers[id] =
             std::make_unique<DDSimulationChecker>(qc1, qc2, configuration);
-        auto* checker = dynamic_cast<DDSimulationChecker*>(checkers[id].get());
+        auto* const checker =
+            dynamic_cast<DDSimulationChecker*>(checkers[id].get());
         {
-          std::lock_guard stateGeneratorLock(stateGeneratorMutex);
+          const std::lock_guard stateGeneratorLock(stateGeneratorMutex);
           checker->setRandomInitialState(stateGenerator);
         }
         if (!done) {
@@ -495,13 +492,12 @@ void EquivalenceCheckingManager::checkParallel() {
     threads.at(*completedID).join();
 
     // in case non-equivalence has been shown, the execution can be stopped
-    auto*      checker = checkers.at(*completedID).get();
-    const auto result  = checker->getEquivalence();
+    const auto* const checker = checkers.at(*completedID).get();
+    const auto        result  = checker->getEquivalence();
 
     if (result == EquivalenceCriterion::NoInformation) {
       std::clog << "Finished equivalence check provides no information. "
-                   "Something probably went wrong. Exiting."
-                << std::endl;
+                   "Something probably went wrong. Exiting.\n";
       break;
     }
 
@@ -511,9 +507,9 @@ void EquivalenceCheckingManager::checkParallel() {
 
       // some special handling in case non-equivalence has been shown by a
       // simulation run
-      if (const auto* simulationChecker =
-              dynamic_cast<DDSimulationChecker*>(checker)) {
-        results.performedSimulations++;
+      if (const auto* const simulationChecker =
+              dynamic_cast<const DDSimulationChecker*>(checker)) {
+        ++results.performedSimulations;
 
         if (configuration.simulation.storeCEXinput) {
           results.cexInput = simulationChecker->getInitialVector();
@@ -529,14 +525,14 @@ void EquivalenceCheckingManager::checkParallel() {
 
     // the alternating and the construction checker provide definitive answers
     // once they finish
-    if ((dynamic_cast<DDAlternatingChecker*>(checker) != nullptr) ||
-        (dynamic_cast<DDConstructionChecker*>(checker) != nullptr)) {
+    if ((dynamic_cast<const DDAlternatingChecker*>(checker) != nullptr) ||
+        (dynamic_cast<const DDConstructionChecker*>(checker) != nullptr)) {
       setAndSignalDone();
       results.equivalence = result;
       break;
     }
 
-    if (dynamic_cast<ZXEquivalenceChecker*>(checker) != nullptr) {
+    if (dynamic_cast<const ZXEquivalenceChecker*>(checker) != nullptr) {
       results.equivalence = result;
       if (result == EquivalenceCriterion::EquivalentUpToGlobalPhase ||
           (result == EquivalenceCriterion::ProbablyNotEquivalent &&
@@ -549,7 +545,7 @@ void EquivalenceCheckingManager::checkParallel() {
     }
 
     // at this point, the only option is that this is a simulation checker
-    if (dynamic_cast<DDSimulationChecker*>(checker) != nullptr) {
+    if (dynamic_cast<const DDSimulationChecker*>(checker) != nullptr) {
       // if the simulation has not shown the non-equivalence, then both circuits
       // are considered probably equivalent
       results.equivalence = EquivalenceCriterion::ProbablyEquivalent;
@@ -558,10 +554,10 @@ void EquivalenceCheckingManager::checkParallel() {
       // it has to be checked, whether further simulations shall be conducted
       if (results.startedSimulations < configuration.simulation.maxSims) {
         threads[*completedID] = std::thread([&, this, id = *completedID] {
-          auto* simChecker =
+          auto* const simChecker =
               dynamic_cast<DDSimulationChecker*>(checkers[id].get());
           {
-            std::lock_guard stateGeneratorLock(stateGeneratorMutex);
+            const std::lock_guard stateGeneratorLock(stateGeneratorMutex);
             simChecker->setRandomInitialState(stateGenerator);
           }
           if (!done) {

--- a/src/EquivalenceCheckingManager.cpp
+++ b/src/EquivalenceCheckingManager.cpp
@@ -452,8 +452,10 @@ void EquivalenceCheckingManager::checkParallel() {
 
   if (runSimulation) {
     const auto effectiveThreadsLeft = effectiveThreads - threads.size();
+    const auto simulationsToStart =
+        std::min(effectiveThreadsLeft, configuration.simulation.maxSims);
     // launch as many simulations as possible
-    for (std::size_t i = 0; i < effectiveThreadsLeft && !done; ++i) {
+    for (std::size_t i = 0; i < simulationsToStart && !done; ++i) {
       threads.emplace_back([this, &queue, id] {
         checkers[id] =
             std::make_unique<DDSimulationChecker>(qc1, qc2, configuration);


### PR DESCRIPTION
The introduction of the ZX checker introduced a potential endless loop in the parallel equivalence check.
If it is detected that the ZX checker cannot be run on the given circuits an additional thread was spawned conducting a simulation run that was never signaled to be done and hence led to an endless loop.
Ci didn't show this until now since the error only happens for systems where `std::hardware_concurrency >= 18`.

This PR addresses this bug by introducing a sanity check before spawning simulations.

It also fixes some linter warnings that popped up along the way.