### PR TITLE
Added handling of global phases

### DIFF
--- a/src/EquivalenceCheckingManager.cpp
+++ b/src/EquivalenceCheckingManager.cpp
@@ -337,7 +337,8 @@ void EquivalenceCheckingManager::checkSequential() {
 
       results.equivalence = result;
       // break if equivalence has been shown
-      if (result == EquivalenceCriterion::EquivalentUpToGlobalPhase) {
+      if (result == EquivalenceCriterion::EquivalentUpToGlobalPhase ||
+          result == EquivalenceCriterion::Equivalent) {
         done = true;
         doneCond.notify_one();
       }
@@ -535,6 +536,7 @@ void EquivalenceCheckingManager::checkParallel() {
     if (dynamic_cast<const ZXEquivalenceChecker*>(checker) != nullptr) {
       results.equivalence = result;
       if (result == EquivalenceCriterion::EquivalentUpToGlobalPhase ||
+          result == EquivalenceCriterion::Equivalent ||
           (result == EquivalenceCriterion::ProbablyNotEquivalent &&
            configuration.onlyZXCheckerConfigured())) {
         setAndSignalDone();

--- a/src/checker/zx/ZXChecker.cpp
+++ b/src/checker/zx/ZXChecker.cpp
@@ -13,6 +13,7 @@
 #include "zx/FunctionalityConstruction.hpp"
 
 #include <chrono>
+#include <iostream>
 #include <optional>
 
 namespace ec {
@@ -79,7 +80,11 @@ EquivalenceCriterion ZXEquivalenceChecker::run() {
     equivalence = EquivalenceCriterion::NoInformation;
   } else {
     if (equivalent) {
-      equivalence = EquivalenceCriterion::EquivalentUpToGlobalPhase;
+      if (miter.globalPhaseIsZero()) {
+        equivalence = EquivalenceCriterion::Equivalent;
+      } else {
+        equivalence = EquivalenceCriterion::EquivalentUpToGlobalPhase;
+      }
     } else {
       equivalence = EquivalenceCriterion::ProbablyNotEquivalent;
     }

--- a/src/checker/zx/ZXChecker.cpp
+++ b/src/checker/zx/ZXChecker.cpp
@@ -13,7 +13,6 @@
 #include "zx/FunctionalityConstruction.hpp"
 
 #include <chrono>
-#include <iostream>
 #include <optional>
 
 namespace ec {

--- a/test/test_zx.cpp
+++ b/test/test_zx.cpp
@@ -224,6 +224,20 @@ TEST_F(ZXTest, ZXConfiguredForInvalidCircuitSequential) {
             ec::EquivalenceCriterion::NoInformation);
 }
 
+TEST_F(ZXTest, GlobalPhase) {
+  auto qc = qc::QuantumComputation(1);
+  qc.rz(0, zx::PI / 8);
+
+  auto qcPrime = qc::QuantumComputation(1);
+  qcPrime.phase(0, zx::PI / 8);
+
+  ecm = std::make_unique<ec::EquivalenceCheckingManager>(qc, qcPrime, config);
+  ecm->run();
+
+  EXPECT_EQ(ecm->getResults().equivalence,
+            ec::EquivalenceCriterion::EquivalentUpToGlobalPhase);
+}
+
 class ZXTestCompFlow : public testing::TestWithParam<std::string> {
 protected:
   qc::QuantumComputation qcOriginal;

--- a/test/test_zx.cpp
+++ b/test/test_zx.cpp
@@ -115,8 +115,7 @@ TEST_F(ZXTest, CloseButNotEqual) {
                                                          qcAlternative, config);
 
   ecm->run();
-  EXPECT_EQ(ecm->equivalence(),
-            ec::EquivalenceCriterion::EquivalentUpToGlobalPhase);
+  EXPECT_EQ(ecm->equivalence(), ec::EquivalenceCriterion::Equivalent);
 }
 
 TEST_F(ZXTest, NotEqual) {


### PR DESCRIPTION
This PR allows the ZXChecker to distinguish true equivalence and equivalence up to a global phase.