### PR TITLE
🔧 Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
       interval: "weekly"
       day: "friday"
       time: "06:00"
+      timezone: "Europe/Vienna"
     assignees:
       - "burgholzer"
 
@@ -15,14 +16,9 @@ updates:
       interval: "weekly"
       day: "friday"
       time: "06:00"
+      timezone: "Europe/Vienna"
     assignees:
       - "burgholzer"
-    ignore:
-      - dependency-name: "actions/*"
-        # Official actions have moving tags like v1
-        # that are used, so they don't need updates here
-        update-types:
-          ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: "pip"
     directory: "/"
@@ -30,5 +26,6 @@ updates:
       interval: "weekly"
       day: "friday"
       time: "06:00"
+      timezone: "Europe/Vienna"
     assignees:
       - "burgholzer"


### PR DESCRIPTION
This PR updates the dependabot configuration of the project.
For one, it adds proper timezones to the configuration.
Additionally, it removes the `ignore` config for GHA actions as recommended by https://github.com/scikit-hep/repo-review. 