### PR TITLE
🐍🔧  Specify Metadata via PEP 621

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,13 +1,6 @@
-include CMakeLists.txt
-recursive-include include *.hpp
-recursive-include jkq *.py
-recursive-include src *.cpp
-recursive-include mqt *.cpp
-recursive-include mqt CMakeLists.txt
-recursive-include src CMakeLists.txt
-
 prune docs
 prune test
+prune .idea
 
 graft extern/qfr
 prune **/.github
@@ -19,9 +12,7 @@ prune **/plots
 prune **/test
 prune **/tests
 
-prune extern/qfr/extern/json/benchmarks
 prune extern/qfr/extern/json/include
-prune extern/qfr/extern/json/third_party
 prune extern/qfr/extern/dd_package/extern
 prune extern/qfr/extern/zx/extern/googletest
 prune extern/qfr/extern/zx/extern/boost/config/checks

--- a/mqt/qcec/verify_compilation_flow.py
+++ b/mqt/qcec/verify_compilation_flow.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-if TYPE_CHECKING or sys.version_info < (3, 9, 0):
+if sys.version_info < (3, 10, 0):
     import importlib_resources as resources
 else:
     from importlib import resources

--- a/noxfile.py
+++ b/noxfile.py
@@ -40,7 +40,7 @@ def pylint(session: Session) -> None:
 
     session.install("pylint")
     session.install("-e", ".")
-    session.run("pylint", "--recursive=y", "mqt/qcec", *session.posargs)
+    session.run("pylint", "mqt.qcec", "--extension-pkg-allow-list=mqt.qcec.pyqcec", *session.posargs)
 
 
 @nox.session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=64",
+    "setuptools>=61",
     "setuptools_scm[toml]>=6.4",
     "ninja>=1.10; sys_platform != 'win32'",
     "cmake>=3.14",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,68 @@
 [build-system]
 requires = [
-    "setuptools>=45",
+    "setuptools>=64",
     "setuptools_scm[toml]>=6.4",
     "ninja>=1.10; sys_platform != 'win32'",
     "cmake>=3.14",
 ]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "mqt.qcec"
+description = "A tool for Quantum Circuit Equivalence Checking"
+readme = "README.md"
+authors = [
+    { name = "Lukas Burgholzer", email = "lukas.burgholzer@jku.at"}
+]
+keywords = ["MQT", "quantum computing", "design automation", "equivalence checking", "verification"]
+license = { file = "LICENSE.md" }
+
+classifiers=[
+    "Development Status :: 5 - Production/Stable",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: C++",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: MacOS",
+    "Operating System :: POSIX :: Linux",
+    "Intended Audience :: Science/Research",
+    "Natural Language :: English",
+    "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
+]
+requires-python = ">=3.7"
+dependencies = [
+    "importlib_resources>=5.9; python_version < '3.10'",
+    "qiskit-terra~=0.21.0"
+]
+dynamic = ["version"]
+
+[project.optional-dependencies]
+test = ["pytest>=7"]
+coverage = ["coverage[toml]~=6.4.2", "pytest-cov~=3.0.0"]
+docs = [
+    "sphinx>=5.1.1",
+    "sphinx-rtd-theme",
+    "sphinxcontrib-bibtex~=2.5",
+    "sphinx-copybutton",
+    "sphinx-hoverxref~=1.1.3",
+    "pybtex>=0.24",
+    "importlib_metadata>=3.6; python_version < '3.10'",
+]
+dev = ["mqt.qcec[test, coverage, docs]"]
+
+[project.urls]
+Homepage = "https://github.com/cda-tum/qcec"
+Documentation = "https://qcec.readthedocs.io"
+"Bug Tracker" = "https://github.com/cda-tum/qcec/issues"
+Discussions = "https://github.com/cda-tum/qcec/discussions"
+Research = "https://www.cda.cit.tum.de/research/quantum_verification/"
+
+[tool.setuptools.packages.find]
+include = ["mqt.*"]
 
 [tool.setuptools_scm]
 

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,9 @@ from setuptools.command.build_ext import build_ext
 
 
 class CMakeExtension(Extension):
-    def __init__(self, name, sourcedir="", namespace=""):
+    def __init__(self, name, sourcedir=""):
         Extension.__init__(self, name, sources=[])
         self.sourcedir = os.path.abspath(sourcedir)
-        self.namespace = namespace
 
 
 class CMakeBuild(build_ext):
@@ -20,7 +19,6 @@ class CMakeBuild(build_ext):
 
         version = get_version(relative_to=__file__)
 
-        self.package = ext.namespace
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
         # required for auto-detection of auxiliary "native" libs
         if not extdir.endswith(os.path.sep):
@@ -86,12 +84,12 @@ class CMakeBuild(build_ext):
                 pass
         subprocess.check_call(["cmake", ext.sourcedir] + cmake_args, cwd=self.build_temp)
         subprocess.check_call(
-            ["cmake", "--build", ".", "--target", ext.name] + build_args,
+            ["cmake", "--build", ".", "--target", ext.name.split(".")[-1]] + build_args,
             cwd=self.build_temp,
         )
 
 
 setup(
-    ext_modules=[CMakeExtension("pyqcec", namespace="mqt.qcec")],
+    ext_modules=[CMakeExtension("mqt.qcec.pyqcec")],
     cmdclass={"build_ext": CMakeBuild},
 )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import re
 import subprocess
 import sys
 
-from setuptools import Extension, find_namespace_packages, setup
+from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
 
@@ -91,62 +91,7 @@ class CMakeBuild(build_ext):
         )
 
 
-README_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "README.md")
-with open(README_PATH) as readme_file:
-    README = readme_file.read()
-
 setup(
-    name="mqt.qcec",
-    author="Lukas Burgholzer",
-    author_email="lukas.burgholzer@jku.at",
-    description="A tool for Quantum Circuit Equivalence Checking",
-    long_description=README,
-    long_description_content_type="text/markdown",
-    python_requires=">=3.7",
-    license="MIT",
-    url="https://www.cda.cit.tum.de/research/quantum_verification/",
     ext_modules=[CMakeExtension("pyqcec", namespace="mqt.qcec")],
     cmdclass={"build_ext": CMakeBuild},
-    zip_safe=False,
-    packages=find_namespace_packages(include=["mqt.*"]),
-    include_package_data=True,
-    package_data={"": ["profiles/*.profile", "py.typed"]},
-    install_requires=["qiskit-terra~=0.21.0", "importlib_resources>=5.9; python_version < '3.10'"],
-    extras_require={
-        "test": ["pytest~=7.1.1"],
-        "coverage": ["coverage[toml]~=6.4.2", "pytest-cov~=3.0.0"],
-        "docs": [
-            "sphinx==5.1.1",
-            "sphinx-rtd-theme==1.0.0",
-            "sphinxcontrib-bibtex==2.5.0",
-            "sphinx-copybutton==0.4.0",
-            "sphinx-hoverxref==1.1.3",
-            "pybtex>=0.24",
-            "importlib_metadata>=3.6; python_version < '3.10'",
-        ],
-        "dev": ["mqt.qcec[test, coverage, docs]"],  # requires Pip 21.2 or newer
-    },
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: C++",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: Microsoft :: Windows",
-        "Operating System :: MacOS",
-        "Operating System :: POSIX :: Linux",
-        "Intended Audience :: Science/Research",
-        "Natural Language :: English",
-        "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
-    ],
-    keywords="MQT quantum verification",
-    project_urls={
-        "Source": "https://github.com/cda-tum/qcec/",
-        "Tracker": "https://github.com/cda-tum/qcec/issues",
-        "Research": "https://www.cda.cit.tum.de/research/quantum_verification/",
-        "Documentation": "https://qcec.readthedocs.io",
-    },
 )

--- a/test/python/test.py
+++ b/test/python/test.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from mqt import qcec
 from qiskit import QuantumCircuit, transpile
-from qiskit.test.mock import FakeAthens
+from qiskit.providers.fake_provider import FakeAthens
 
 if __name__ == "__main__":
     # create quantum circuit for GHZ state


### PR DESCRIPTION
This PR moves the metadata of the Python package from the `setup.py` file to the `pyproject.toml` file according to [PEP 621](https://peps.python.org/pep-0621/). `pyproject.toml` has been decided to be the future of Python packaging regarding metadata (and more). It also simplifies some of the code and makes it far more convenient to specify metadata and extras.

Unfortunately, this still does not allow to drop the `setup.py` file since there is no real alternative for building binary extensions at the moment. In the future we might look into https://github.com/scikit-build/scikit-build as a potential alternative.

This PR also brings along a couple of smaller fixes:
 - `pyqcec` was accidentally created as a top-level module
 - a recent update seems to have broken `pylint`. this is now fixed again
 - the `importlib_resources` import was off, leading to a missing package on Python 3.9