### PR TITLE
📌 More leniency on the `qiskit-terra` version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers=[
 requires-python = ">=3.7"
 dependencies = [
     "importlib_resources>=5.9; python_version < '3.10'",
-    "qiskit-terra~=0.21.0"
+    "qiskit-terra>=0.20,<0.22"
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
## Description

This PR loosens the dependency on `qiskit-terra` from `~=0.21.0` to `>=0.20,<0.22`. This ensures that QCEC can be installed alongside a wider range of Qiskit versions.

In principle, QCEC is compatible far further back down the history of `qiskit-terra`. However, Qiskit still regularly deprecates and changes interfaces. Maintaining compatibility with a large number of versions quickly becomes a burden. Hence `qiskit-terra~=0.19.0` is no longer officially supported.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
