### PR TITLE
🐛 Fix potential underflow bug in max simulation computation

### DIFF
--- a/include/Configuration.hpp
+++ b/include/Configuration.hpp
@@ -66,12 +66,26 @@ public:
   // configuration options for the simulation scheme
   struct Simulation {
     double      fidelityThreshold = 1e-8;
-    std::size_t maxSims =
-        std::max(16U, std::thread::hardware_concurrency() - 2U);
-    StateType   stateType      = StateType::ComputationalBasis;
-    std::size_t seed           = 0U;
-    bool        storeCEXinput  = false;
-    bool        storeCEXoutput = false;
+    std::size_t maxSims           = computeMaxSims();
+    StateType   stateType         = StateType::ComputationalBasis;
+    std::size_t seed              = 0U;
+    bool        storeCEXinput     = false;
+    bool        storeCEXoutput    = false;
+
+    // this function makes sure that the maximum number of simulations is
+    // configured properly.
+    static std::size_t computeMaxSims() {
+      constexpr std::size_t defaultMaxSims                 = 16U;
+      constexpr std::size_t defaultConfiguredOtherCheckers = 2U;
+      const auto            systemThreads = std::thread::hardware_concurrency();
+      // catch the case where hardware_concurrency() returns 0 or the other
+      // pre-configured checkers already use up all the available threads
+      if (systemThreads < defaultConfiguredOtherCheckers) {
+        return defaultMaxSims;
+      }
+      return std::max(defaultMaxSims,
+                      systemThreads - defaultConfiguredOtherCheckers);
+    }
   };
 
   Execution     execution{};


### PR DESCRIPTION
## Description

The following computation is currently being used to compute the maximum number of simulations to run:

https://github.com/cda-tum/qcec/blob/5ae4e6144d9144a128dbb21827960d2169d250ce/include/Configuration.hpp#L69-L70

However, `std::thread::hardware_concurrency` is not guaranteed to return a meaningful result. From its documentation:

> Number of concurrent threads supported. If the value is not well defined or not computable, returns ​`0​`.

In the above computation, if `std::thread::hardware_concurrency` happens to return `0` or reports only a single available thread, the subtraction would underflow. As a result, the maximum would be set to roughly `2**64` simulations -- essentially guaranteeing an endless run.

This PR adds an additional sanity check to make sure that the maximum number of simulations is properly set up.

Fixes #128 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
