### PR TITLE
🔧 Codecov Config Update

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -20,3 +20,7 @@ parsers:
     branch_detection:
       conditional: no
       loop: no
+
+codecov:
+  notify:
+    after_n_builds: 2


### PR DESCRIPTION
## Description

Per default, codecov reports the coverage status on a PR once the first report is uploaded. However, if there is more than one job tracking coverage (C++ and Python, for example), then this incorrectly reports a lowered coverage until both reports have been received.

Conveniently, codecov offers an option to delay the notification so that it only posts the notification after both reports have been received. 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
