### PR TITLE
🐛 Fix and improve the calculation of the tasks to execute

### DIFF
--- a/src/EquivalenceCheckingManager.cpp
+++ b/src/EquivalenceCheckingManager.cpp
@@ -374,18 +374,35 @@ void EquivalenceCheckingManager::checkParallel() {
         << "Trying to use more threads than the underlying architecture claims "
            "to support. Over-subscription might impact performance!\n";
   }
+  const auto maxThreads = configuration.execution.nthreads;
 
-  const auto maxThreads      = configuration.execution.nthreads;
-  const auto runAlternating  = configuration.execution.runAlternatingChecker;
-  const auto runConstruction = configuration.execution.runConstructionChecker;
-  const auto runZX           = configuration.execution.runZXChecker;
-  const auto runSimulation   = configuration.execution.runSimulationChecker &&
-                             configuration.simulation.maxSims > 0;
-
-  const std::size_t tasksToExecute =
-      configuration.simulation.maxSims * (static_cast<int>(runSimulation)) +
-      (runAlternating ? 1U : 0U) + (runConstruction ? 1U : 0U) +
-      (runZX ? 1U : 0U);
+  std::size_t tasksToExecute = 0U;
+  if (configuration.execution.runAlternatingChecker) {
+    ++tasksToExecute;
+  }
+  if (configuration.execution.runConstructionChecker) {
+    ++tasksToExecute;
+  }
+  if (configuration.execution.runSimulationChecker) {
+    if (configuration.simulation.maxSims > 0U) {
+      tasksToExecute += configuration.simulation.maxSims;
+    } else {
+      configuration.execution.runSimulationChecker = false;
+    }
+  }
+  if (configuration.execution.runZXChecker) {
+    if (zx::FunctionalityConstruction::transformableToZX(&qc1) &&
+        zx::FunctionalityConstruction::transformableToZX(&qc2)) {
+      ++tasksToExecute;
+    } else if (configuration.onlyZXCheckerConfigured()) {
+      std::clog << "Only ZX checker specified but one of the circuits contains "
+                   "operations not supported by this checker! Exiting!\n";
+      results.equivalence = EquivalenceCriterion::NoInformation;
+      setAndSignalDone();
+    } else {
+      configuration.execution.runZXChecker = false;
+    }
+  }
 
   const auto effectiveThreads = std::min(maxThreads, tasksToExecute);
 
@@ -401,7 +418,7 @@ void EquivalenceCheckingManager::checkParallel() {
   std::vector<std::thread> threads{};
   threads.reserve(effectiveThreads);
 
-  if (runAlternating) {
+  if (configuration.execution.runAlternatingChecker) {
     // start a new thread that constructs and runs the alternating check
     threads.emplace_back([this, &queue, id] {
       checkers[id] =
@@ -412,7 +429,7 @@ void EquivalenceCheckingManager::checkParallel() {
     ++id;
   }
 
-  if (runConstruction && !done) {
+  if (configuration.execution.runConstructionChecker && !done) {
     // start a new thread that constructs and runs the construction check
     threads.emplace_back([this, &queue, id] {
       checkers[id] =
@@ -425,29 +442,20 @@ void EquivalenceCheckingManager::checkParallel() {
     ++id;
   }
 
-  if (runZX && !done) {
-    if (zx::FunctionalityConstruction::transformableToZX(&qc1) &&
-        zx::FunctionalityConstruction::transformableToZX(&qc2)) {
-      // start a new thread that constructs and runs the ZX checker
-      threads.emplace_back([this, &queue, id] {
-        checkers[id] =
-            std::make_unique<ZXEquivalenceChecker>(qc1, qc2, configuration);
-        if (!done) {
-          checkers[id]->run();
-        }
-        queue.push(id);
-      });
-      ++id;
-    } else if (configuration.onlyZXCheckerConfigured()) {
-      std::clog << "Only ZX checker specified but one of the circuits contains "
-                   "operations not supported by this checker! Exiting!\n";
-      checkers.clear();
-      results.equivalence = EquivalenceCriterion::NoInformation;
-      done                = true;
-    }
+  if (configuration.execution.runZXChecker && !done) {
+    // start a new thread that constructs and runs the ZX checker
+    threads.emplace_back([this, &queue, id] {
+      checkers[id] =
+          std::make_unique<ZXEquivalenceChecker>(qc1, qc2, configuration);
+      if (!done) {
+        checkers[id]->run();
+      }
+      queue.push(id);
+    });
+    ++id;
   }
 
-  if (runSimulation) {
+  if (configuration.execution.runSimulationChecker) {
     const auto effectiveThreadsLeft = effectiveThreads - threads.size();
     const auto simulationsToStart =
         std::min(effectiveThreadsLeft, configuration.simulation.maxSims);


### PR DESCRIPTION
## Description

While working on QCEC, I noticed a strange segfault happening in the parallel checker tests that did not seem to be caught by CI. The segfault occurred whenever the `ZXChecker` was configured to run, but couldn't actually because one of the circuits was not transformable to a ZX-Diagram. This lead to the ZX checker not being allocated and, hence, triggering a segfault when iterating over all the checkers during the printing of the equivalence checking manager.

This PR fixes the underlying issue by improving the computation of the tasks to execute and performing the ZX capability check beforehand. As a nice side effect, this also fixes some warnings reported locally by clang-tidy.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
