### PR TITLE
🚸 Ancillary and garbage handling

### DIFF
--- a/include/checker/dd/DDAlternatingChecker.hpp
+++ b/include/checker/dd/DDAlternatingChecker.hpp
@@ -39,6 +39,12 @@ public:
     j["checker"] = "decision_diagram_alternating";
   }
 
+  /// a function to determine whether the alternating checker can handle
+  /// checking both circuits. In particular, it checks whether both circuits
+  /// contain non-idle ancillaries.
+  static bool canHandle(const qc::QuantumComputation& qc1,
+                        const qc::QuantumComputation& qc2);
+
 private:
   qc::MatrixDD functionality{};
 

--- a/src/EquivalenceCheckingManager.cpp
+++ b/src/EquivalenceCheckingManager.cpp
@@ -196,6 +196,16 @@ EquivalenceCheckingManager::EquivalenceCheckingManager(
     fixOutputPermutationMismatch();
   }
 
+  // check whether the alternating checker is configured and can handle the
+  // circuits
+  if (configuration.execution.runAlternatingChecker &&
+      !DDAlternatingChecker::canHandle(this->qc1, this->qc2)) {
+    std::clog << "[QCEC] Warning: alternating checker cannot handle the "
+                 "circuits. Falling back to construction checker.\n";
+    this->configuration.execution.runAlternatingChecker  = false;
+    this->configuration.execution.runConstructionChecker = true;
+  }
+
   // initialize the stimuli generator
   stateGenerator = StateGenerator(configuration.simulation.seed);
 

--- a/src/checker/dd/DDAlternatingChecker.cpp
+++ b/src/checker/dd/DDAlternatingChecker.cpp
@@ -18,24 +18,11 @@ void DDAlternatingChecker::initialize() {
   std::vector<bool> ancillary(nqubits);
   for (auto q = static_cast<dd::Qubit>(nqubits - 1U); q >= 0; --q) {
     if (qc1.logicalQubitIsAncillary(q) && qc2.logicalQubitIsAncillary(q)) {
-      bool found1  = false;
-      bool isIdle1 = false;
-      if (const auto it = std::find_if(
-              qc1.initialLayout.cbegin(), qc1.initialLayout.cend(),
-              [q](const auto& mapping) { return mapping.second == q; });
-          it != qc1.initialLayout.cend()) {
-        found1  = true;
-        isIdle1 = qc1.isIdleQubit(it->first);
-      }
-      bool found2  = false;
-      bool isIdle2 = false;
-      if (const auto it = std::find_if(
-              qc2.initialLayout.cbegin(), qc2.initialLayout.cend(),
-              [q](const auto& mapping) { return mapping.second == q; });
-          it != qc2.initialLayout.cend()) {
-        found2  = true;
-        isIdle2 = qc2.isIdleQubit(it->first);
-      }
+      const auto [found1, physical1] = qc1.containsLogicalQubit(q);
+      const auto isIdle1             = found1 && qc1.isIdleQubit(*physical1);
+
+      const auto [found2, physical2] = qc2.containsLogicalQubit(q);
+      const auto isIdle2             = found2 && qc2.isIdleQubit(*physical2);
 
       // qubit only really exists or is acted on in one of the circuits
       if ((found1 != found2) || (isIdle1 != isIdle2)) {

--- a/src/checker/dd/DDEquivalenceChecker.cpp
+++ b/src/checker/dd/DDEquivalenceChecker.cpp
@@ -52,14 +52,19 @@ DDEquivalenceChecker<DDType, DDPackage>::equals(const DDType& e,
     // product trace(U V^-1) and comparing it to some threshold. in a similar
     // fashion, we can simply compare U V^-1 with the identity, which results in
     // a much simpler check that is not prone to overflow.
-    bool isClose{};
-    if (e.p->isIdentity()) {
-      isClose =
-          dd->isCloseToIdentity(f, configuration.functionality.traceThreshold);
-    } else if (f.p->isIdentity()) {
-      isClose =
-          dd->isCloseToIdentity(e, configuration.functionality.traceThreshold);
+    bool       isClose{};
+    const bool eIsClose =
+        dd->isCloseToIdentity(e, configuration.functionality.traceThreshold);
+    const bool fIsClose =
+        dd->isCloseToIdentity(f, configuration.functionality.traceThreshold);
+    if (eIsClose || fIsClose) {
+      // if any of the DDs is close to the identity (structure), the result can
+      // be decided by whether both DDs are close enough to the identity.
+      isClose = eIsClose && fIsClose;
     } else {
+      // otherwise, one DD needs to be inverted before multiplying both of them
+      // together and checking whether the resulting DD is close enough to the
+      // identity.
       auto g = dd->multiply(e, dd->conjugateTranspose(f));
       isClose =
           dd->isCloseToIdentity(g, configuration.functionality.traceThreshold);

--- a/test/test_equality.cpp
+++ b/test/test_equality.cpp
@@ -156,4 +156,10 @@ TEST_F(EqualityTest, AutomaticSwitchToConstructionChecker) {
   // ancillary and garbage qubit
   const auto result = ecm.equivalence();
   EXPECT_EQ(result, ec::EquivalenceCriterion::Equivalent);
+
+  // also check an exception is thrown
+  // if the checker is configured after initialization
+  ecm.reset();
+  ecm.setAlternatingChecker(true);
+  EXPECT_THROW(ecm.run(), std::invalid_argument);
 }

--- a/test/test_equality.cpp
+++ b/test/test_equality.cpp
@@ -125,3 +125,35 @@ TEST_F(EqualityTest, SimulationMoreThan64Qubits) {
   std::cout << ecm << std::endl;
   EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::ProbablyEquivalent);
 }
+
+TEST_F(EqualityTest, AutomaticSwitchToConstructionChecker) {
+  // add ancillary qubits to both circuits
+  qc1.addAncillaryQubit(1, -1);
+  qc2.addAncillaryQubit(1, -1);
+
+  // perform the same action on both circuits' primary qubit
+  qc1.x(0);
+  qc2.x(0);
+
+  // perform a different action on the ancillary qubit
+  qc1.x(1);
+  qc2.z(1);
+
+  // setup default configuration
+  config = ec::Configuration{};
+  ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
+
+  // this should notice that the alternating checker is not capable of running
+  // the circuit and should switch to the construction checker
+  const auto runConfig = ecm.getConfiguration();
+  EXPECT_TRUE(runConfig.execution.runConstructionChecker);
+  EXPECT_FALSE(runConfig.execution.runAlternatingChecker);
+
+  // run the equivalence checker
+  ecm.run();
+
+  // both circuits should be equivalent since their action only differs on an
+  // ancillary and garbage qubit
+  const auto result = ecm.equivalence();
+  EXPECT_EQ(result, ec::EquivalenceCriterion::Equivalent);
+}

--- a/test/test_equality.cpp
+++ b/test/test_equality.cpp
@@ -157,10 +157,11 @@ TEST_F(EqualityTest, AutomaticSwitchToConstructionChecker) {
   const auto result = ecm.equivalence();
   EXPECT_EQ(result, ec::EquivalenceCriterion::Equivalent);
 
-  // Check an error is raised for a checker configured after initialization.
-  // Note: this has to be a death test since the exception is raised in a
-  // different thread and hence cannot be caught by the test.
+  // Check an exception is raised for a checker configured after initialization.
+  // Note: this exception can only be caught in sequential mode since it is
+  // raised in a different thread otherwise.
   ecm.reset();
   ecm.setAlternatingChecker(true);
-  EXPECT_DEATH(ecm.run(), ".*");
+  ecm.setParallel(false);
+  EXPECT_THROW(ecm.run(), std::invalid_argument);
 }

--- a/test/test_equality.cpp
+++ b/test/test_equality.cpp
@@ -157,9 +157,10 @@ TEST_F(EqualityTest, AutomaticSwitchToConstructionChecker) {
   const auto result = ecm.equivalence();
   EXPECT_EQ(result, ec::EquivalenceCriterion::Equivalent);
 
-  // also check an exception is thrown
-  // if the checker is configured after initialization
+  // Check an error is raised for a checker configured after initialization.
+  // Note: this has to be a death test since the exception is raised in a
+  // different thread and hence cannot be caught by the test.
   ecm.reset();
   ecm.setAlternatingChecker(true);
-  EXPECT_THROW(ecm.run(), std::invalid_argument);
+  EXPECT_DEATH(ecm.run(), ".*");
 }


### PR DESCRIPTION
## Description

This PR ensures that the way ancillary and garbage qubits are treated in QCEC is theoretically sound and removes several corresponding "TODOs" in the code.

In particular, the alternating DD checker cannot be used whenever both circuits contain ancillary qubits that are acted upon.
Up until now, this did not cause any issues since, for the predominant use case of verifying compilation results, only one of the circuits typically uses ancillary qubits.
As a solution, the default verification scheme switches to the construction checker whenever it detects that the alternating checker is not capable of handling the circuits in question.
Furthermore, the alternating checker emits an exception should it ever be configured to still run on instances it can't handle.

Last, but not least, the matrix equivalence check is slightly improved so that it does not incur an inversion and a multiplication when ancillaries are used.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
