### PR TITLE
🔧 Separate C++ and Python Coverage

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -7,13 +7,30 @@ coverage:
   range: 60..90
   precision: 1
   status:
-    project:
-      default:
-        threshold: 0.5%
-    patch:
-      default:
-        threshold: 1%
-        target: 90%
+    project: off
+    patch: off
+
+flag_management:
+  individual_flags:
+    - name: cpp
+      paths:
+        - "include/**/*.hpp"
+        - "src/**/*.cpp"
+      statuses:
+        - type: project
+          threshold: 0.5%
+        - type: patch
+          threshold: 1%
+          target: 90%
+    - name: python
+      paths:
+        - "mqt/**/*.py"
+      statuses:
+        - type: project
+          threshold: 0.5%
+        - type: patch
+          threshold: 1%
+          target: 95%
 
 parsers:
   gcov:

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -11,25 +11,24 @@ coverage:
     patch: off
 
 flag_management:
+  default_rules:
+    statuses:
+      - type: project
+        target: auto
+        threshold: 0.5%
+      - type: patch
+        target: 90%
+        threshold: 1%
   individual_flags:
     - name: cpp
       paths:
-        - "include/**/*.hpp"
-        - "src/**/*.cpp"
-      statuses:
-        - type: project
-          threshold: 0.5%
-        - type: patch
-          threshold: 1%
-          target: 90%
+        - "include"
+        - "src"
     - name: python
       paths:
         - "mqt/**/*.py"
       statuses:
-        - type: project
-          threshold: 0.5%
         - type: patch
-          threshold: 1%
           target: 95%
 
 parsers:


### PR DESCRIPTION
## Description

Codecov now allows to explicitly split coverage metrics depending on certain flags being set.
The corresponding flags for the CI jobs where already introduced in #169.
This PR updates the configuration itself to use these flags and produce separate coverage checks for C++ and Python.

The envisioned benefit is that it becomes clearer, which part of the code base needs more tests.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
