### PR TITLE
🚸 `qiskit-terra>=0.22.0` compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers=[
 requires-python = ">=3.7"
 dependencies = [
     "importlib_resources>=5.9; python_version < '3.10'",
-    "qiskit-terra>=0.20,<0.22"
+    "qiskit-terra>=0.20"
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,8 @@ classifiers=[
 requires-python = ">=3.7"
 dependencies = [
     "importlib_resources>=5.9; python_version < '3.10'",
-    "qiskit-terra>=0.20"
+    "qiskit-terra>=0.20",
+    "retworkx>=0.11.0,<0.12.0"
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
## Description

This PR makes QCEC compatible with the newest `qiskit-terra` release, which changed some internals of the `QuantumCircuit` class that broke the circuit import for compiled circuits in QCEC.

The cause for this issue was the change in https://github.com/Qiskit/qiskit-terra/pull/8802.
The (backwards-compatible) solution has been implemented in https://github.com/cda-tum/qfr/pull/207.

This PR also drops the upper-cap on the `qiskit-terra` version easing the integration with future versions of qiskit.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
