### PR TITLE
📌 More lenient package requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers=[
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: C++",
     "License :: OSI Approved :: MIT License",
     "Operating System :: Microsoft :: Windows",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,22 +36,22 @@ classifiers=[
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "importlib_resources>=5.9; python_version < '3.10'",
+    "importlib_resources>=5.0; python_version < '3.10'",
     "qiskit-terra>=0.20,<0.22"
 ]
 dynamic = ["version"]
 
 [project.optional-dependencies]
 test = ["pytest>=7"]
-coverage = ["mqt.qcec[test]", "coverage[toml]~=6.4.2", "pytest-cov~=3.0.0"]
+coverage = ["mqt.qcec[test]", "coverage[toml]>=6.3", "pytest-cov>=3"]
 docs = [
-    "sphinx>=5.1.1",
+    "sphinx>=5",
     "sphinx-rtd-theme",
-    "sphinxcontrib-bibtex~=2.5",
+    "sphinxcontrib-bibtex>=2.4.2",
     "sphinx-copybutton",
-    "sphinx-hoverxref~=1.1.3",
+    "sphinx-hoverxref",
     "pybtex>=0.24",
-    "importlib_metadata>=3.6; python_version < '3.10'",
+    "importlib_metadata>=4.4; python_version < '3.10'",
     "ipython",
     "ipykernel",
     "nbsphinx",


### PR DESCRIPTION
## Description

This small PR relaxes the (lower and upper) caps on QCEC's Python dependencies in order to increase it's compatibility with other libraries. This is mainly inspired by https://iscinumpy.dev/post/bound-version-constraints/.

In the future, it might make sense to introduce a CI check that ensures the lowest allowed versions still work. Such a job would be helpful for ensuring that QCEC continues to work with a large variety of external libraries and hardly depends on them. 
Pip `constraint` files could work for that purpose. 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
