### PR TITLE
❄️ Potential fix for flaky Python test

### DIFF
--- a/mqt/qcec/compilation_flow_profiles.py
+++ b/mqt/qcec/compilation_flow_profiles.py
@@ -196,7 +196,9 @@ def compute_cost(
     Compute the cost of a circuit by transpiling the circuit
     to a given ``basis_gates`` gate set and a certain ``optimization_level``.
     """
-    transpiled_circuit = transpile(qc, basis_gates=basis_gates, optimization_level=optimization_level)
+    transpiled_circuit = transpile(
+        qc, basis_gates=basis_gates, optimization_level=optimization_level, seed_transpiler=0
+    )
     return transpiled_circuit.size()
 
 


### PR DESCRIPTION
## Description

Tests in the recent months have shown that the Qiskit transpiler is flaky when compiling single gates with optimization level O3. This leads to slightly different compilation flow profiles in QCEC and, as a consequence, sporadic failures in the test suite.

This PR adds a fixed seed to the respective `transpile` call in the hope of eliminating this flakiness.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
