### PR TITLE
✨ Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,8 +6,19 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
   wheels_artifacts:
     path: "wheelhouse/*"
 
+.clone_script: &clone |
+  if [ -z "$CIRRUS_PR" ]; then
+    git clone --recursive --branch=$CIRRUS_BRANCH https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
+    git reset --hard $CIRRUS_CHANGE_IN_REPO
+  else
+    git clone --recursive https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
+    git fetch origin pull/$CIRRUS_PR/head:pull/$CIRRUS_PR
+    git reset --hard $CIRRUS_CHANGE_IN_REPO
+  fi
+
 linux_aarch64_task:
   name: Build Linux aarch64 wheels.
+  clone_script: *clone
   compute_engine_instance:
     image_project: cirrus-images
     image: family/docker-builder-arm64
@@ -21,6 +32,7 @@ linux_aarch64_task:
 
 macos_arm64_task:
   name: Build macOS arm64 wheels.
+  clone_script: *clone
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-xcode
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,32 @@
+build_and_store_wheels: &BUILD_AND_STORE_WHEELS
+  install_cibuildwheel_script:
+    - python -m pip install cibuildwheel==2.11.2
+  run_cibuildwheel_script:
+    - cibuildwheel
+  wheels_artifacts:
+    path: "wheelhouse/*"
+
+linux_aarch64_task:
+  name: Build Linux aarch64 wheels.
+  compute_engine_instance:
+    image_project: cirrus-images
+    image: family/docker-builder-arm64
+    architecture: arm64
+    platform: linux
+    cpu: 4
+
+  install_pre_requirements_script:
+    - apt install -y python3-venv python-is-python3
+  <<: *BUILD_AND_STORE_WHEELS
+
+macos_arm64_task:
+  name: Build macOS arm64 wheels.
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-monterey-xcode
+
+  env:
+    PATH: /opt/homebrew/opt/python@3.10/bin:$PATH
+  install_pre_requirements_script:
+    - brew install python@3.10
+    - ln -s python3 /opt/homebrew/opt/python@3.10/bin/python
+  <<: *BUILD_AND_STORE_WHEELS

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -44,3 +44,18 @@ macos_arm64_task:
     - brew install python@3.10
     - ln -s python3 /opt/homebrew/opt/python@3.10/bin/python
   <<: *BUILD_AND_STORE_WHEELS
+
+publish_task:
+  name: Upload to PyPI
+  container: { image: "python:3.10-bullseye" }
+  depends_on: [linux_aarch64, macos_arm64]
+  only_if: "$CIRRUS_RELEASE != ''"
+  env:
+    TWINE_REPOSITORY: pypi
+    TWINE_USERNAME: __token__
+    TWINE_PASSWORD: ENCRYPTED[963630b0d5f7e9ad0aba1e51f63d69ecc36ea550ccce3a382cee179da6b286ccc644aebd482f97a919f1f6a1810a0d25]
+  install_script: pip install twine
+  publish_script:
+    - curl -L https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/wheels.zip | tar xvz -C dist
+    - python -m twine check dist/*
+    - python -m twine upload dist/*

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,6 +25,8 @@ linux_aarch64_task:
     architecture: arm64
     platform: linux
     cpu: 4
+  env:
+    CIBW_SKIP: "*-musllinux_*"
 
   install_pre_requirements_script:
     - apt install -y python3-venv python-is-python3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,52 +14,20 @@ concurrency:
 
 jobs:
   build_wheels:
-    name: ${{ matrix.os }}${{ matrix.archname }}${{ matrix.libc }} wheels
+    name: ${{ matrix.os }}$ wheels
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        arch: [x86_64]
-        archname: [""]
-        skip: ["*-musllinux_*"]
-        libc: [""]
-        include:
-          - arch: arm64
-            archname: "-arm64"
-            os: macos-latest
-          - arch: x86_64
-            os: ubuntu-latest
-            skip: "*-manylinux_*"
-            libc: "-musl"
-    #          - arch:     aarch64
-    #            archname: "-arm64"
-    #            os:       ubuntu-latest
-    #            qemu:     true
-    #          - arch:     aarch64
-    #            archname: "-arm64"
-    #            os:       ubuntu-latest
-    #            qemu:     true
-    #            skip:     "*-manylinux_*"
-    #            libc:     "-musl"
-
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive
       - uses: ilammy/msvc-dev-cmd@v1
-      #      - name: Install QEMU
-      #        uses: docker/setup-qemu-action@v1
-      #        if:   matrix.qemu
-      #        with:
-      #          platforms: arm64
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.11.2
-        env:
-          CIBW_ARCHS_MACOS: ${{ matrix.arch }}
-          CIBW_ARCHS_LINUX: ${{ matrix.arch }}
-          CIBW_SKIP: ${{ matrix.skip }}
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build_wheels:
-    name: ${{ matrix.os }}$ wheels
+    name: ${{ matrix.os }} wheels
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ include = ["mqt.*"]
 
 [tool.cibuildwheel]
 build = "cp3*"
+skip = "*-musllinux_*"
 archs = "auto64"
 test-skip = "cp311-* *-macosx_arm64 *-musllinux* *aarch64"
 test-extras = ["test"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ requires-python = ">=3.7"
 dependencies = [
     "importlib_resources>=5.0; python_version < '3.10'",
     "qiskit-terra>=0.20",
-    "retworkx>=0.11.0,<0.12.0"
 ]
 dynamic = ["version"]
 
@@ -98,7 +97,11 @@ testpaths = ["test/python"]
 addopts = ["-ra", "--strict-markers", "--strict-config", "--showlocals"]
 log_cli_level = "INFO"
 xfail_strict = true
-filterwarnings = ["error"]
+filterwarnings = [
+    "error",
+    # See https://github.com/Qiskit/rustworkx/pull/728
+    'ignore:RetworkxLoader.exec_module\(\) not found; falling back to load_module\(\):ImportWarning',
+]
 
 [tool.coverage.run]
 source = ["mqt.qcec"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,6 @@ include = ["mqt.*"]
 build = "cp3*"
 skip = "*-musllinux_*"
 archs = "auto64"
-test-skip = "cp311-* *-macosx_arm64 *-musllinux* *aarch64"
 test-extras = ["test"]
 test-command = "python -c \"from mqt import qcec\""
 environment = { DEPLOY = "ON" }


### PR DESCRIPTION
## Description

With this PR, Apple Silicon wheels are natively built on Cirrus CI and testing is enabled. In addition, Linux ARM wheels are built there.
Furthermore, Qiskit now ships Python 3.11 wheels; so testing wheels under that Python is no longer skipped.

🔥 This PR drops `musllinux` wheels since `qiskit` also doesn't provide corresponding wheels. As a result, Qiskit has to be built from source under these systems anyway.

Overall, this considerably simplifies the Python wheel setup.

Solves #149

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
