### PR TITLE
🔧 add Python 3.11 tests

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -32,12 +32,14 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.10"]
+        python-version: ["3.7", "3.11"]
         include:
           - runs-on: ubuntu-latest
-            python-version: 3.8
+            python-version: "3.8"
           - runs-on: ubuntu-latest
-            python-version: 3.9
+            python-version: "3.9"
+          - runs-on: ubuntu-latest
+            python-version: "3.10"
     steps:
       - uses: actions/checkout@v3
         with:
@@ -73,7 +75,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.10"]
+        python-version: ["3.7", "3.11"]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,7 +7,7 @@ from nox.sessions import Session
 
 nox.options.sessions = ["lint", "tests"]
 
-PYTHON_ALL_VERSIONS = ["3.7", "3.8", "3.9", "3.10"]
+PYTHON_ALL_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
 if os.environ.get("CI", None):
     nox.options.error_on_missing_interpreters = True


### PR DESCRIPTION
## Description

Qiskit now ships Python 3.11 wheels, so there is no reason left to not test under Python 3.11.
This PR adds the corresponding CI runs and modifies the existing ones.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
