### PR TITLE
👷 Add CI workflows for `s390x` and `ppc64le` architectures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,8 +48,33 @@ jobs:
         with:
           path: dist/*.tar.gz
 
+  build_wheels_emulation:
+    name: ${{ matrix.python }} wheels on ${{ matrix.arch }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ["s390x", "ppc64le"]
+        python: ["cp37-*", "cp38-*", "cp39-*", "cp310-*", "cp311-*"]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.11.2
+        env:
+          CIBW_ARCHS_LINUX: ${{ matrix.arch }}
+          CIBW_BUILD: ${{ matrix.python }}
+          CIBW_TEST_SKIP: "cp*"
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
+
   upload_pypi:
-    needs: [build_wheels, build_sdist]
+    needs: [build_wheels, build_sdist, build_wheels_emulation]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:

--- a/.github/workflows/emulated-wheels.yml
+++ b/.github/workflows/emulated-wheels.yml
@@ -1,4 +1,4 @@
-name: Python Packaging
+name: Python Packaging Emulated Wheels
 
 on:
   release:
@@ -13,43 +13,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_wheels:
-    name: ${{ matrix.os }} wheels
-    runs-on: ${{ matrix.os }}
+  build_wheels_emulation:
+    name: ${{ matrix.python }} wheels on ${{ matrix.arch }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        arch: ["s390x", "ppc64le"]
+        python: ["cp37-*", "cp38-*", "cp39-*", "cp310-*", "cp311-*"]
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive
-      - uses: ilammy/msvc-dev-cmd@v1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.11.2
+        env:
+          CIBW_ARCHS_LINUX: ${{ matrix.arch }}
+          CIBW_BUILD: ${{ matrix.python }}
+          CIBW_TEST_SKIP: "cp*"
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
 
-  build_sdist:
-    name: sdist
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          submodules: recursive
-      - name: Build SDist
-        run: pipx run build --sdist
-      - name: Install sdist
-        run: python -m pip install --verbose dist/*.tar.gz
-      - uses: actions/upload-artifact@v3
-        with:
-          path: dist/*.tar.gz
-
   upload_pypi:
-    needs: [build_wheels, build_sdist]
+    needs: [build_wheels_emulation]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:

--- a/.github/workflows/emulated-wheels.yml
+++ b/.github/workflows/emulated-wheels.yml
@@ -3,9 +3,6 @@ name: Python Packaging Emulated Wheels
 on:
   release:
     types: [published]
-  pull_request:
-  push:
-    branches: [main]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Description

This PR adds CI support for building `s390x` and `ppc64le` Python wheels. This completes the long list of wheels that is offered by Qiskit. Hence, once this PR is merged and a release is created, QCEC provides binary wheels for any platform supported by Qiskit.
Since these are emulated platforms and GitHub places a 6h timeout on jobs, the jobs are split up as much as possible (creating 10 new jobs). Jobs for these platforms are split into a separate workflow file and only run on releases.

resolves #153 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
