### PR TITLE
Fix bug with hadamards in idenitity diagram.

### DIFF
--- a/src/checker/zx/ZXChecker.cpp
+++ b/src/checker/zx/ZXChecker.cpp
@@ -56,8 +56,14 @@ EquivalenceCriterion ZXEquivalenceChecker::run() {
 
     const auto nQubits = miter.getNQubits();
     for (std::size_t i = 0U; i < nQubits; ++i) {
-      const auto& in  = miter.getInput(i);
-      const auto& out = miter.incidentEdge(in, 0U).to;
+      const auto& in   = miter.getInput(i);
+      const auto& edge = miter.incidentEdge(in, 0U);
+
+      if (edge.type == zx::EdgeType::Hadamard) {
+        equivalent = false;
+        break;
+      }
+      const auto& out = edge.to;
 
       if (p1.at(static_cast<dd::Qubit>(miter.getVData(in).value().qubit)) !=
           p2.at(static_cast<dd::Qubit>(miter.getVData(out).value().qubit))) {

--- a/test/test_zx.cpp
+++ b/test/test_zx.cpp
@@ -278,3 +278,17 @@ TEST_P(ZXTestCompFlow, EquivalenceCompilationFlow) {
   std::cout << ecm->toString() << std::endl;
   EXPECT_TRUE(ecm->getResults().consideredEquivalent());
 }
+
+TEST(ZXTestsMisc, IdentityNotHadamard) {
+  const auto qc1 = qc::QuantumComputation(1);
+  auto       qc2 = qc::QuantumComputation(1);
+  qc2.h(0);
+
+  auto ecm = ec::EquivalenceCheckingManager(qc1, qc2);
+  ecm.disableAllCheckers();
+  ecm.setZXChecker(true);
+  ecm.run();
+
+  EXPECT_EQ(ecm.getResults().equivalence,
+            ec::EquivalenceCriterion::ProbablyNotEquivalent);
+}


### PR DESCRIPTION
## Description

Fixes a bug where the ZX-checker simplifies a the equivalence checking miter to a diagram consisting only of wires. If this happens the checker erroneously didn't check whether the wires are hadamard wires.

Fixes #200 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
