### PR TITLE
🐍🔥 Drop Python 3.7 support

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -32,10 +32,8 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.11"]
+        python-version: ["3.8", "3.11"]
         include:
-          - runs-on: ubuntu-latest
-            python-version: "3.8"
           - runs-on: ubuntu-latest
             python-version: "3.9"
           - runs-on: ubuntu-latest
@@ -79,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.11"]
+        python-version: ["3.8", "3.11"]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
     rev: "v3.3.1"
     hooks:
       - id: pyupgrade
-        args: ["--py37-plus"]
+        args: ["--py38-plus"]
 
   # Sort includes
   - repo: https://github.com/PyCQA/isort

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you have any questions, feel free to contact us via [quantum.cda@xcit.tum.de]
 
 ## Getting Started
 
-QCEC is available via [PyPI](https://pypi.org/project/mqt.qcec/) for Linux, macOS, and Windows.
+QCEC is available via [PyPI](https://pypi.org/project/mqt.qcec/) for Linux, macOS, and Windows and supports Python 3.8 to 3.11.
 
 ```console
 (venv) $ pip install mqt.qcec
@@ -52,7 +52,7 @@ print(result.equivalence)
 
 ## System Requirements and Building
 
-The implementation is compatible with any C++17 compiler and a minimum CMake version of 3.19.
+The implementation is compatible with any C++17 compiler, a minimum CMake version of 3.19, and Python 3.8+.
 Please refer to the [documentation](https://qcec.readthedocs.io/en/latest/) on how to build the project.
 
 Building (and running) is continuously tested under Linux, macOS, and Windows using the [latest available system versions for GitHub Actions](https://github.com/actions/virtual-environments).

--- a/docs/source/Installation.rst
+++ b/docs/source/Installation.rst
@@ -33,6 +33,11 @@ In most practical cases (under 64-bit Linux, MacOS incl. Apple Silicon, and Wind
 
         (venv) $ pip install --upgrade pip setuptools wheel
 
+.. warning::
+    As of version 2.2.0, support for Python 3.7 has been officially dropped.
+    We strongly recommend that users upgrade to a more recent version of Python to ensure compatibility and continue receiving updates and support.
+    Thank you for your understanding.
+
 A Detailed Walk Through
 #######################
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,7 +7,7 @@ from nox.sessions import Session
 
 nox.options.sessions = ["lint", "tests"]
 
-PYTHON_ALL_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11"]
+PYTHON_ALL_VERSIONS = ["3.8", "3.9", "3.10", "3.11"]
 
 if os.environ.get("CI", None):
     nox.options.error_on_missing_interpreters = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ license = { file = "LICENSE.md" }
 classifiers=[
     "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -35,7 +34,7 @@ classifiers=[
     "Natural Language :: English",
     "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "importlib_resources>=5.0; python_version < '3.10'",
     "qiskit-terra>=0.20",
@@ -130,7 +129,7 @@ src_paths = ["mqt/qcec", "test/python"]
 
 [tool.mypy]
 files = ["mqt/qcec", "test/python", "setup.py"]
-python_version = "3.7"
+python_version = "3.8"
 strict = true
 show_error_codes = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
@@ -142,7 +141,7 @@ module = ["qiskit.*"]
 ignore_missing_imports = true
 
 [tool.pylint]
-master.py-version = "3.7"
+master.py-version = "3.8"
 master.jobs = "0"
 reports.output-format = "colorized"
 similarities.ignore-imports = "yes"


### PR DESCRIPTION
## Description

Qiskit(-terra) is bound to drop Python 3.7 support in the upcoming `0.25.0` update and a warning is issued since the newly released `0.23.0`. 
To avoid any future disruptions, Python 3.7 support is dropped with this PR.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
