### PR TITLE
♻️ Simplify Timeout Handling

### DIFF
--- a/include/Configuration.hpp
+++ b/include/Configuration.hpp
@@ -11,13 +11,10 @@
 #include "dd/Package.hpp"
 #include "nlohmann/json.hpp"
 
-#include <chrono>
 #include <functional>
 #include <thread>
 
 namespace ec {
-
-using namespace std::chrono_literals;
 
 class Configuration {
 public:
@@ -27,7 +24,7 @@ public:
 
     bool        parallel = true;
     std::size_t nthreads = std::max(2U, std::thread::hardware_concurrency());
-    std::chrono::seconds timeout = 0s;
+    double      timeout  = 0.; // in seconds
 
     bool runConstructionChecker = false;
     bool runSimulationChecker   = true;
@@ -148,8 +145,8 @@ public:
     exe["run_simulation_checker"]   = execution.runSimulationChecker;
     exe["run_alternating_checker"]  = execution.runAlternatingChecker;
     exe["run_zx_checker"]           = execution.runZXChecker;
-    if (execution.timeout > 0s) {
-      exe["timeout"] = execution.timeout.count();
+    if (execution.timeout > 0.) {
+      exe["timeout"] = execution.timeout;
     }
     auto& opt = config["optimizations"];
     opt["fix_output_permutation_mismatch"] =

--- a/include/EquivalenceCheckingManager.hpp
+++ b/include/EquivalenceCheckingManager.hpp
@@ -102,7 +102,7 @@ public:
   void setNThreads(std::size_t nthreads) {
     configuration.execution.nthreads = nthreads;
   }
-  void setTimeout(std::chrono::seconds timeout) {
+  void setTimeout(const double timeout) {
     configuration.execution.timeout = timeout;
   }
   void setConstructionChecker(bool run) {

--- a/mqt/qcec/bindings.cpp
+++ b/mqt/qcec/bindings.cpp
@@ -73,9 +73,8 @@ static std::unique_ptr<EquivalenceCheckingManager> createManagerFromOptions(
     const bool        parallel           = true,
     const std::size_t nthreads           = std::max(2U,
                                                     std::thread::hardware_concurrency()),
-    const std::chrono::seconds timeout   = 0s,
-    const bool                 runConstructionChecker = false,
-    const bool                 runSimulationChecker   = true,
+    const double timeout = 0., const bool runConstructionChecker = false,
+    const bool runSimulationChecker  = true,
     const bool runAlternatingChecker = true, const bool runZXChecker = true,
     // Optimization
     const bool fixOutputPermutationMismatch = false,
@@ -278,7 +277,7 @@ PYBIND11_MODULE(pyqcec, m) {
          "numerical_tolerance"_a = dd::ComplexTable<>::tolerance(),
          "parallel"_a            = true,
          "nthreads"_a = std::max(2U, std::thread::hardware_concurrency()),
-         "timeout"_a = 0s, "run_construction_checker"_a = false,
+         "timeout"_a = 0., "run_construction_checker"_a = false,
          "run_simulation_checker"_a = true, "run_alternating_checker"_a = true,
          "run_zx_checker"_a = true, "fix_output_permutation_mismatch"_a = false,
          "fuse_single_qubit_gates"_a = true, "reconstruct_swaps"_a = true,
@@ -316,10 +315,9 @@ PYBIND11_MODULE(pyqcec, m) {
            "Set the maximum number of :attr:`threads "
            "<.Configuration.Execution.nthreads>` to use.")
       .def("set_timeout", &EquivalenceCheckingManager::setTimeout,
-           "timeout"_a = 0.0,
+           "timeout"_a = 0.,
            "Set a :attr:`timeout <.Configuration.Execution.timeout>` (in "
-           "seconds) for :func:`~EquivalenceCheckingManager.run`. The timeout "
-           "can also be specified by a :class:`float`.")
+           "seconds) for :func:`~EquivalenceCheckingManager.run`.")
       .def("set_construction_checker",
            &EquivalenceCheckingManager::setConstructionChecker,
            "enable"_a = false,
@@ -574,8 +572,7 @@ PYBIND11_MODULE(pyqcec, m) {
       .def_readwrite(
           "timeout", &Configuration::Execution::timeout,
           "Set a timeout for :meth:`~.EquivalenceCheckingManager.run` (in "
-          "seconds). Either a :class:`datetime.timedelta` or :class:`float`. "
-          "Defaults to :code:`0.`, which means no timeout.")
+          "seconds). Defaults to :code:`0.`, which means no timeout.")
       .def_readwrite(
           "run_construction_checker",
           &Configuration::Execution::runConstructionChecker,

--- a/mqt/qcec/parameterized.py
+++ b/mqt/qcec/parameterized.py
@@ -182,7 +182,7 @@ def check_parameterized(
 
     update_stats(res)
 
-    timeout: float | None = kwargs["timeout"].total_seconds() if kwargs.get("timeout") else None
+    timeout: float | None = kwargs.get("timeout")
 
     timeout = __adjust_timeout(timeout, res)
 

--- a/mqt/qcec/pyqcec.pyi
+++ b/mqt/qcec/pyqcec.pyi
@@ -3,8 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, ClassVar, overload
 
 if TYPE_CHECKING:
-    import datetime
-
     from mqt.qcec.types import ApplicationSchemeName, EquivalenceCriterionName, StateTypeName
 
 class ApplicationScheme:
@@ -47,7 +45,7 @@ class Configuration:
         run_construction_checker: bool
         run_simulation_checker: bool
         run_zx_checker: bool
-        timeout: datetime.timedelta
+        timeout: float
         def __init__(self) -> None: ...
 
     class Functionality:
@@ -109,7 +107,7 @@ class EquivalenceCheckingManager:
         numerical_tolerance: float = ...,
         parallel: bool = ...,
         nthreads: int = ...,
-        timeout: datetime.timedelta | float = ...,
+        timeout: float = ...,
         run_construction_checker: bool = ...,
         run_simulation_checker: bool = ...,
         run_alternating_checker: bool = ...,
@@ -163,7 +161,7 @@ class EquivalenceCheckingManager:
     def set_simulation_checker(self, enable: bool = ...) -> None: ...
     def set_simulation_gate_cost_profile(self, profile: str = ...) -> None: ...
     def set_state_type(self, state_type: StateType | StateTypeName = ...) -> None: ...
-    def set_timeout(self, timeout: datetime.timedelta | float = ...) -> None: ...
+    def set_timeout(self, timeout: float = ...) -> None: ...
     def set_tolerance(self, tolerance: float = ...) -> None: ...
     def set_trace_threshold(self, threshold: float = ...) -> None: ...
     def set_zx_checker(self, enable: bool = ...) -> None: ...

--- a/test/legacy/test_journal.cpp
+++ b/test/legacy/test_journal.cpp
@@ -138,13 +138,11 @@ INSTANTIATE_TEST_SUITE_P(
     });
 
 TEST_P(JournalTestNonEQ, PowerOfSimulation) {
-  using namespace std::chrono_literals;
-
   config.execution.runAlternatingChecker  = false;
   config.execution.runConstructionChecker = false;
   config.execution.runSimulationChecker   = true;
   config.execution.parallel               = false;
-  config.execution.timeout                = 60s;
+  config.execution.timeout                = 60.;
   config.simulation.maxSims               = 16U;
   config.application.simulationScheme = ec::ApplicationSchemeType::Sequential;
 
@@ -192,14 +190,12 @@ TEST_P(JournalTestNonEQ, PowerOfSimulation) {
 }
 
 TEST_P(JournalTestNonEQ, PowerOfSimulationParallel) {
-  using namespace std::chrono_literals;
-
   config.execution.runAlternatingChecker  = false;
   config.execution.runConstructionChecker = false;
   config.execution.runZXChecker           = false;
   config.execution.runSimulationChecker   = true;
   config.execution.parallel               = true;
-  config.execution.timeout                = 60s;
+  config.execution.timeout                = 60.;
   config.simulation.maxSims               = 16U;
   config.application.simulationScheme = ec::ApplicationSchemeType::Sequential;
 
@@ -258,8 +254,6 @@ protected:
   std::string transpiledFile{};
 
   void SetUp() override {
-    using namespace std::chrono_literals;
-
     config.execution.parallel               = false;
     config.execution.runConstructionChecker = false;
     config.execution.runAlternatingChecker  = false;
@@ -267,7 +261,7 @@ protected:
     config.execution.runSimulationChecker   = false;
     config.simulation.maxSims               = 16;
     config.application.simulationScheme = ec::ApplicationSchemeType::OneToOne;
-    config.execution.timeout            = 60s;
+    config.execution.timeout            = 60.;
 
     std::stringstream ss{};
     ss << testTranspiledDir << GetParam() << "_transpiled.qasm";

--- a/test/python/test_configuration.py
+++ b/test/python/test_configuration.py
@@ -36,10 +36,9 @@ def test_application_scheme(
 
 
 def test_timeout() -> None:
-    import datetime
-
     config = qcec.Configuration()
-    config.execution.timeout = datetime.timedelta(seconds=60)
+    config.execution.timeout = 60
+    config.execution.timeout = 60.0
 
 
 @pytest.mark.parametrize(

--- a/test/python/test_symbolic.py
+++ b/test/python/test_symbolic.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import datetime
-
 import pytest
 from qiskit import QuantumCircuit, transpile
 from qiskit.circuit import Parameter
@@ -114,16 +112,14 @@ def test_equivalent_rz_commute(rz_commute_lhs: QuantumCircuit, rz_commute_rhs_co
 
 
 def test_non_equivalent_rz_commute(rz_commute_lhs: QuantumCircuit, rz_commute_rhs_incorrect: QuantumCircuit) -> None:
-    result = qcec.verify(rz_commute_lhs, rz_commute_rhs_incorrect, timeout=datetime.timedelta(seconds=3600))
+    result = qcec.verify(rz_commute_lhs, rz_commute_rhs_incorrect, timeout=3600)
     assert result.equivalence == qcec.EquivalenceCriterion.not_equivalent
 
 
 def test_non_equivalent_phase_rz_commute(
     rz_commute_lhs: QuantumCircuit, rz_commute_rhs_incorrect: QuantumCircuit
 ) -> None:
-    result = qcec.verify(
-        rz_commute_lhs, rz_commute_rhs_incorrect, additional_instantiations=2, timeout=datetime.timedelta(seconds=3600)
-    )
+    result = qcec.verify(rz_commute_lhs, rz_commute_rhs_incorrect, additional_instantiations=2, timeout=3600)
     assert result.equivalence == qcec.EquivalenceCriterion.not_equivalent
 
 
@@ -172,9 +168,7 @@ def test_verify_compilation_on_optimization_levels(original_circuit: QuantumCirc
     to the 5-qubit IBMQ Athens architecture with various optimization levels.
     """
     compiled_circuit = transpile(original_circuit, backend=FakeAthens(), optimization_level=optimization_level)
-    result = qcec.verify_compilation(
-        original_circuit, compiled_circuit, optimization_level, timeout=datetime.timedelta(seconds=3600)
-    )
+    result = qcec.verify_compilation(original_circuit, compiled_circuit, optimization_level, timeout=3600)
     assert (
         result.equivalence == qcec.EquivalenceCriterion.equivalent
         or result.equivalence == qcec.EquivalenceCriterion.equivalent_up_to_global_phase

--- a/test/python/test_verify.py
+++ b/test/python/test_verify.py
@@ -41,7 +41,7 @@ def test_verify_kwargs(original_circuit: QuantumCircuit, alternative_circuit: Qu
     """
     Test the verification of two equivalent circuits with a keyword argument.
     """
-    result = qcec.verify(original_circuit, alternative_circuit, timeout=3600.0)
+    result = qcec.verify(original_circuit, alternative_circuit, timeout=3600)
     assert result.equivalence == qcec.EquivalenceCriterion.equivalent
 
 
@@ -49,9 +49,8 @@ def test_verify_config(original_circuit: QuantumCircuit, alternative_circuit: Qu
     """
     Test the verification of two equivalent circuits with a configuration object.
     """
-    import datetime
 
     config = qcec.Configuration()
-    config.execution.timeout = datetime.timedelta(seconds=3600)
+    config.execution.timeout = 3600
     result = qcec.verify(original_circuit, alternative_circuit, config)
     assert result.equivalence == qcec.EquivalenceCriterion.equivalent

--- a/test/test_symbolic.cpp
+++ b/test/test_symbolic.cpp
@@ -48,8 +48,6 @@ TEST_F(SymbolicTest, SymbolicNonEqu) {
 }
 
 TEST_F(SymbolicTest, Timeout) {
-  using namespace std::chrono_literals;
-
   // construct large circuit
   constexpr auto numLayers = 100000;
   symQc1                   = qc::QuantumComputation(2);
@@ -62,7 +60,7 @@ TEST_F(SymbolicTest, Timeout) {
     symQc2.rx(0, xMonom);
   }
   ec::Configuration config{};
-  config.execution.timeout = 1s;
+  config.execution.timeout = 1;
   auto ecm = ec::EquivalenceCheckingManager(symQc1, symQc2, config);
 
   ecm.run();

--- a/test/test_zx.cpp
+++ b/test/test_zx.cpp
@@ -78,7 +78,6 @@ TEST_F(ZXTest, NonEquivalent) {
 
 TEST_F(ZXTest, Timeout) {
   using namespace qc::literals;
-  using namespace std::chrono_literals;
 
   // construct large circuit
   constexpr auto numLayers = 10000;
@@ -92,7 +91,7 @@ TEST_F(ZXTest, Timeout) {
     qcAlternative.h(0);
   }
 
-  config.execution.timeout = 1s;
+  config.execution.timeout = 1;
   ecm = std::make_unique<ec::EquivalenceCheckingManager>(qcOriginal,
                                                          qcAlternative, config);
 


### PR DESCRIPTION
## Description

In the past, the way timeouts could be set was handled quite awkwardly by relying on `pybind`'s automatic conversion from `std::chrono::seconds` to some Python `datetime` object.
This PR simplifies the overall handling by changing the type of the `timeout` configuration parameter to a `double`.

Fixes #176

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
