### PR TITLE
🐛 Fix compatibility check in alternating checker

### DIFF
--- a/test/python/test_verify.py
+++ b/test/python/test_verify.py
@@ -63,3 +63,19 @@ def test_verify_config(original_circuit: QuantumCircuit, alternative_circuit: Qu
     config.execution.timeout = 3600
     result = qcec.verify(original_circuit, alternative_circuit, config)
     assert result.equivalence == qcec.EquivalenceCriterion.equivalent
+
+
+def test_compiled_circuit_without_measurements() -> None:
+    """
+    This is a regression test for https://github.com/cda-tum/qcec/issues/236.
+    It makes sure that circuits compiled without measurements are handled correctly.
+    """
+    from qiskit import transpile
+    from qiskit.providers.fake_provider import FakeAthens
+
+    qc = QuantumCircuit(1)
+    qc.x(0)
+    qc_compiled = transpile(qc, backend=FakeAthens())
+
+    result = qcec.verify(qc, qc_compiled)
+    assert result.equivalence == qcec.EquivalenceCriterion.equivalent


### PR DESCRIPTION
## Description

Fix an oversight in one of the compatibility checks for the alternating checker that could cause segfaults.
An exception was thrown erroneously if both circuits contained ancillary qubits that were idle.
While fixing, I took the opportunity to simplify the underlying code and eliminate some code duplication.

Fixes #236 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
