### PR TITLE
💡♻️ Improve corner-case logic for infering check result

### DIFF
--- a/include/EquivalenceCheckingManager.hpp
+++ b/include/EquivalenceCheckingManager.hpp
@@ -277,6 +277,10 @@ protected:
     }
   }
 
+  [[nodiscard]] bool simulationsFinished() const {
+    return results.performedSimulations == configuration.simulation.maxSims;
+  }
+
   static void addCircuitDescription(const qc::QuantumComputation& qc,
                                     nlohmann::json&               j) {
     j["name"]     = qc.getName();

--- a/test/legacy/test_journal.cpp
+++ b/test/legacy/test_journal.cpp
@@ -141,6 +141,7 @@ TEST_P(JournalTestNonEQ, PowerOfSimulation) {
   config.execution.runAlternatingChecker  = false;
   config.execution.runConstructionChecker = false;
   config.execution.runSimulationChecker   = true;
+  config.execution.runZXChecker           = false;
   config.execution.parallel               = false;
   config.execution.timeout                = 60.;
   config.simulation.maxSims               = 16U;

--- a/test/test_zx.cpp
+++ b/test/test_zx.cpp
@@ -301,3 +301,27 @@ TEST(ZXTestsMisc, IdentityNotHadamard) {
   EXPECT_EQ(ecm.getResults().equivalence,
             ec::EquivalenceCriterion::ProbablyNotEquivalent);
 }
+
+TEST_F(ZXTest, NonEquivalentCircuit) {
+  // ensure that a non-equivalent circuit with ancillas yields no information
+  qcOriginal = qc::QuantumComputation(2);
+  qcOriginal.x(0);
+  qcAlternative = qc::QuantumComputation(2);
+  qcAlternative.x(0);
+  qcAlternative.swap(0, 1);
+  // emulate the addition of an ancillary register
+  qcAlternative.addAncillaryRegister(3);
+  ecm = std::make_unique<ec::EquivalenceCheckingManager>(qcOriginal,
+                                                         qcAlternative, config);
+  ecm->run();
+  EXPECT_EQ(ecm->getResults().equivalence,
+            ec::EquivalenceCriterion::NoInformation);
+
+  // ensure that enabling another checker allows to detect non-equivalence and
+  // does not abort the computation.
+  ecm->setAlternatingChecker(true);
+  ecm->setParallel(true);
+  ecm->run();
+  EXPECT_EQ(ecm->getResults().equivalence,
+            ec::EquivalenceCriterion::NotEquivalent);
+}


### PR DESCRIPTION
## Description

This PR reworks the logic on how conclusions on the final equivalence are drawn in both, the sequential and the parallel, equivalence checking flows. This also fixes a bug observed in #240 where the ZX checker (correctly) produced `no_information` on non-equivalent circuits, but instead of continuing with the rest of the flow, the computation was aborted.

This PR also introduces some additional logging/warning messages that (hopefully) clearly describe the behavior in some corner cases. I'd expect coverage to decrease for this PR, as those messages are not currently triggered in tests, but are more of a safety precaution.

Fixes #240

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
