### PR TITLE
🔧 Add release drafter workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,48 @@
+name-template: "$REPOSITORY $RESOLVED_VERSION Release"
+tag-template: "v$RESOLVED_VERSION"
+categories:
+  - title: "🚀 Features and Enhancements"
+    labels:
+      - "feature"
+      - "usability"
+  - title: "🐛 Bug Fixes"
+    labels:
+      - "bug"
+  - title: "📄 Documentation"
+    labels:
+      - "documentation"
+  - title: "🤖 CI"
+    labels:
+      - "continuous integration"
+  - title: "📦 Packaging"
+    labels:
+      - "packaging"
+  - title: "⬆️ Dependencies"
+    collapse-after: 5
+    labels:
+      - "dependencies"
+      - "submodules"
+      - "github_actions"
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+change-title-escapes: '\<*_&'
+version-resolver:
+  major:
+    labels:
+      - "major"
+  minor:
+    labels:
+      - "minor"
+  patch:
+    labels:
+      - "patch"
+  default: patch
+autolabeler:
+  - label: "dependencies"
+    title:
+      - "/update pre-commit hooks/i"
+
+template: |
+  ## What Changed 👀
+
+  $CHANGES
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,24 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize]
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

This PR adds the Release Drafter action to the set of GitHub workflows which should make it easier and more automatic to create releases.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
