### PR TITLE
⬆️🪝 Update ruff and use automatic `target-version` inference

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
 
   # Run ruff (subsumes pyupgrade, isort, flake8+plugins, and more)
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.254
+    rev: v0.0.256
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,6 @@ ignore = [
     "PLR2004", # Magic values
     "PLR0913", # Too many arguments
 ]
-target-version = "py38"
 
 # Exclude a variety of commonly ignored directories.
 exclude = [


### PR DESCRIPTION
## Description

This small PR updates the configuration of the ruff pre-commit hook. Since `v0.255`, the `target-version` configuration property can be inferred directly, which allows to simplify the configuration.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
