### PR TITLE
🚸 Ensure exception propagation from threads via `std::async`

### DIFF
--- a/include/checker/dd/DDEquivalenceChecker.hpp
+++ b/include/checker/dd/DDEquivalenceChecker.hpp
@@ -21,7 +21,7 @@ class DDEquivalenceChecker : public EquivalenceChecker {
 public:
   DDEquivalenceChecker(const qc::QuantumComputation& circ1,
                        const qc::QuantumComputation& circ2,
-                       Configuration                 config) noexcept
+                       Configuration                 config)
       : EquivalenceChecker(circ1, circ2, std::move(config)),
         dd(std::make_unique<dd::Package<Config>>(nqubits)),
         taskManager1(TaskManager<DDType, Config>(circ1, dd)),

--- a/include/checker/dd/DDSimulationChecker.hpp
+++ b/include/checker/dd/DDSimulationChecker.hpp
@@ -14,7 +14,7 @@ class DDSimulationChecker final
 public:
   DDSimulationChecker(const qc::QuantumComputation& circ1,
                       const qc::QuantumComputation& circ2,
-                      Configuration                 configuration) noexcept;
+                      Configuration                 configuration);
 
   void setRandomInitialState(StateGenerator& generator);
 

--- a/src/EquivalenceCheckingManager.cpp
+++ b/src/EquivalenceCheckingManager.cpp
@@ -654,7 +654,8 @@ void EquivalenceCheckingManager::checkParallel() {
       // it has to be checked, whether further simulations shall be
       // conducted
       if (results.startedSimulations < configuration.simulation.maxSims) {
-        futures[*completedID] = asyncRunChecker<DDSimulationChecker>(id, queue);
+        futures[*completedID] =
+            asyncRunChecker<DDSimulationChecker>(*completedID, queue);
         ++results.startedSimulations;
       }
     }

--- a/src/EquivalenceCheckingManager.cpp
+++ b/src/EquivalenceCheckingManager.cpp
@@ -723,11 +723,11 @@ void EquivalenceCheckingManager::checkSymbolic() {
   // sets the `done` flag after the timeout has passed
   std::thread timeoutThread{};
   if (configuration.execution.timeout > 0.) {
-    timeoutThread = std::thread([&, timeout = std::chrono::duration<double>(
-                                        configuration.execution.timeout)] {
+    timeoutThread = std::thread([this, timeout = std::chrono::duration<double>(
+                                           configuration.execution.timeout)] {
       std::unique_lock doneLock(doneMutex);
       auto             finished =
-          doneCond.wait_for(doneLock, timeout, [&] { return done; });
+          doneCond.wait_for(doneLock, timeout, [this] { return done; });
       // if the thread has already finished within the timeout,
       // nothing has to be done
       if (!finished) {

--- a/src/checker/dd/DDSimulationChecker.cpp
+++ b/src/checker/dd/DDSimulationChecker.cpp
@@ -8,7 +8,7 @@
 namespace ec {
 DDSimulationChecker::DDSimulationChecker(const qc::QuantumComputation& circ1,
                                          const qc::QuantumComputation& circ2,
-                                         Configuration config) noexcept
+                                         Configuration                 config)
     : DDEquivalenceChecker(circ1, circ2, std::move(config)) {
   initialState = dd->makeZeroState(static_cast<dd::QubitCount>(nqubits));
   initializeApplicationScheme(configuration.application.simulationScheme);

--- a/test/python/test_verify.py
+++ b/test/python/test_verify.py
@@ -78,8 +78,8 @@ def test_compiled_circuit_without_measurements() -> None:
     assert result.equivalence == qcec.EquivalenceCriterion.equivalent
 
 
-def test_cpp_exception_propagation() -> None:
-    """Test that exceptions thrown in the C++ code are propagated correctly."""
+def test_cpp_exception_propagation_internal() -> None:
+    """Test that C++ exceptions caused by code within QCEC are propagated correctly."""
     qc = QuantumCircuit(1)
     qc.x(0)
 
@@ -89,7 +89,18 @@ def test_cpp_exception_propagation() -> None:
     config.execution.run_construction_checker = False
     config.execution.run_zx_checker = False
     config.application.simulation_scheme = qcec.ApplicationScheme.lookahead
-    config.simulation.max_sims = 1
 
     with pytest.raises(ValueError, match="Lookahead application scheme can only be used for matrices."):
+        qcec.verify(qc, qc, configuration=config)
+
+
+def test_cpp_exception_propagation_external() -> None:
+    """Test that C++ exceptions caused by code outside of QCEC are propagated correctly."""
+    qc = QuantumCircuit(129)
+    qc.x(range(129))
+
+    config = qcec.Configuration()
+    config.execution.run_zx_checker = False
+
+    with pytest.raises(ValueError, match="Requested too many qubits from package."):
         qcec.verify(qc, qc, configuration=config)

--- a/test/python/test_verify.py
+++ b/test/python/test_verify.py
@@ -76,3 +76,20 @@ def test_compiled_circuit_without_measurements() -> None:
 
     result = qcec.verify(qc, qc_compiled)
     assert result.equivalence == qcec.EquivalenceCriterion.equivalent
+
+
+def test_cpp_exception_propagation() -> None:
+    """Test that exceptions thrown in the C++ code are propagated correctly."""
+    qc = QuantumCircuit(1)
+    qc.x(0)
+
+    config = qcec.Configuration()
+    config.execution.run_alternating_checker = False
+    config.execution.run_simulation_checker = True
+    config.execution.run_construction_checker = False
+    config.execution.run_zx_checker = False
+    config.application.simulation_scheme = qcec.ApplicationScheme.lookahead
+    config.simulation.max_sims = 1
+
+    with pytest.raises(ValueError, match="Lookahead application scheme can only be used for matrices."):
+        qcec.verify(qc, qc, configuration=config)

--- a/test/test_equality.cpp
+++ b/test/test_equality.cpp
@@ -165,3 +165,30 @@ TEST_F(EqualityTest, AutomaticSwitchToConstructionChecker) {
   ecm.setParallel(false);
   EXPECT_THROW(ecm.run(), std::invalid_argument);
 }
+
+TEST_F(EqualityTest, ExceptionInParallelThread) {
+  qc1.x(0);
+
+  config                                  = ec::Configuration{};
+  config.execution.runAlternatingChecker  = false;
+  config.execution.runConstructionChecker = false;
+  config.execution.runSimulationChecker   = true;
+  config.execution.runZXChecker           = false;
+  config.application.simulationScheme = ec::ApplicationSchemeType::Lookahead;
+
+  ec::EquivalenceCheckingManager ecm(qc1, qc1, config);
+  EXPECT_THROW(ecm.run(), std::invalid_argument);
+}
+
+TEST_F(EqualityTest, ExceptionInParallelThread2) {
+  qc1.addQubitRegister(128U);
+  for (auto i = 0U; i <= 128U; ++i) {
+    qc1.x(i);
+  }
+
+  config                        = ec::Configuration{};
+  config.execution.runZXChecker = false;
+
+  ec::EquivalenceCheckingManager ecm(qc1, qc1, config);
+  EXPECT_THROW(ecm.run(), std::invalid_argument);
+}


### PR DESCRIPTION
## Description

If an unhandled exception occurs in a C++ thread, `std::terminate` is called. This is undesirable, especially from the Python side, since there is no way for the exception to be propagated to Python and, thus, for handling it gracefully.
It just causes a crash of the Python executable.

Fortunately, C++ offers some ways to allow for exceptions from threads to be propagated to the main thread. 
This is done by using `std::async` instead of `std::thread`. Upon creation, it returns an `std::future` object that is used to refer to the return value of the asynchronous computation.
A future can hold the return value, but also an exception. Upon calling `future.get()`, either the value is returned or the stored exception is rethrown.
In this way, any exception happening concurrently is eventually propagated to the main thread and, as a result, to Python.

This also caught some instances of methods being declared `noexcept` despite possibly throwing. This also causes the C++ runtime to call `std::terminate` instead of resulting in a proper error message.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
